### PR TITLE
[fix/16-get-only-public-post] 프로필 포착한 게시글 - 공개 게시글만 조회

### DIFF
--- a/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
@@ -66,7 +66,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     );
 
     @Query("select p from Post p " +
-            "where p.owner = :owner and p.status = 'ACTIVE' and (p.owner = :loginMember or p.postStatus = 'PUBLIC') " +
+            "where p.owner = :owner and p.status = 'ACTIVE' and p.postStatus = 'PUBLIC' " +
             "   and p.owner not in (select b.blockedMember from Block b where b.blocker = :loginMember) " +
             "   and :loginMember not in (select b.blockedMember from Block b where b.blocker = p.owner) " +
             "   and not exists (select t.member from Tag t where t.post = p intersect select b.blockedMember from Block b where b.blocker = :loginMember) " +


### PR DESCRIPTION
## 📒 개요

프로필 포착한 게시글 조회 기능에서 공개 게시글만 조회되도록 수정함.

## 📍 Issue 번호

> #16 

## 🛠️ 작업사항

- [x] 포착한 게시글 조회 쿼리 수정
