### PR TITLE
[feat/26-get-tagged-member] 태그된 유저 조회, 태그 수 제한

### DIFF
--- a/src/main/java/com/apps/pochak/block/dto/response/BlockElement.java
+++ b/src/main/java/com/apps/pochak/block/dto/response/BlockElement.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BlockElement {
+    private Long memberId;
     private String profileImage;
     private String handle;
     private String name;
@@ -18,6 +19,7 @@ public class BlockElement {
     @Builder(builderMethodName = "from")
     public BlockElement(final Block block) {
         Member blockedMember = block.getBlockedMember();
+        this.memberId = blockedMember.getId();
         this.profileImage = blockedMember.getProfileImage();
         this.handle = blockedMember.getHandle();
         this.name = blockedMember.getName();

--- a/src/main/java/com/apps/pochak/comment/dto/response/CommentElement.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/CommentElement.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class CommentElement {
     private Long commentId;
+    private Long memberId;
     private String profileImage;
     private String handle;
     private LocalDateTime createdDate;
@@ -23,6 +24,7 @@ public class CommentElement {
     public CommentElement(final Comment comment) {
         final Member member = comment.getMember();
         this.commentId = comment.getId();
+        this.memberId = member.getId();
         this.profileImage = member.getProfileImage();
         this.handle = member.getHandle();
         this.createdDate = comment.getCreatedDate();

--- a/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
@@ -21,6 +21,7 @@ import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
 @AllArgsConstructor
 public class ParentCommentElement {
     private Long commentId;
+    private Long memberId;
     private String profileImage;
     private String handle;
     private LocalDateTime createdDate;
@@ -43,6 +44,7 @@ public class ParentCommentElement {
     ) {
         final Member member = parentComment.getMember();
         this.commentId = parentComment.getId();
+        this.memberId = member.getId();
         this.profileImage = member.getProfileImage();
         this.handle = member.getHandle();
         this.createdDate = parentComment.getCreatedDate();

--- a/src/main/java/com/apps/pochak/global/api_payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/apps/pochak/global/api_payload/code/status/ErrorStatus.java
@@ -73,6 +73,8 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_POST_ID(BAD_REQUEST, "POST4001", "유효하지 않은 게시물 아이디입니다."),
     NOT_YOUR_POST(UNAUTHORIZED, "POST4002", "해당 게시물의 삭제 권한이 없습니다."),
     PRIVATE_POST(UNAUTHORIZED, "POST4003", "공개되지 않은 게시물입니다."),
+    EXCEED_TAG_LIMIT(BAD_REQUEST, "POST4004", "최대 멤버 태그 수를 초과하였습니다."),
+    INVALID_TAG_INFO(BAD_REQUEST, "POST4005", "태그된 멤버의 정보가 확인되지 않습니다."),
 
     // Tag
     INVALID_TAG_ID(BAD_REQUEST, "TAG4001", "유효하지 않은 태그 아이디입니다."),

--- a/src/main/java/com/apps/pochak/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/apps/pochak/like/domain/repository/LikeRepository.java
@@ -36,6 +36,7 @@ public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
 
     @Query("select  " +
             "new com.apps.pochak.like.dto.response.LikeElement(" +
+            "   m.id, " +
             "   m.handle, " +
             "   m.profileImage, " +
             "   m.name, " +

--- a/src/main/java/com/apps/pochak/like/dto/response/LikeElement.java
+++ b/src/main/java/com/apps/pochak/like/dto/response/LikeElement.java
@@ -1,22 +1,14 @@
 package com.apps.pochak.like.dto.response;
 
-import com.apps.pochak.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class LikeElement {
-
+    private Long memberId;
     private String handle;
     private String profileImage;
     private String name;
     private Boolean follow;
-
-    public LikeElement(final Member member, final Boolean follow) {
-        this.handle = member.getHandle();
-        this.profileImage = member.getProfileImage();
-        this.name = member.getName();
-        this.follow = follow;
-    }
 }

--- a/src/main/java/com/apps/pochak/login/provider/JwtProvider.java
+++ b/src/main/java/com/apps/pochak/login/provider/JwtProvider.java
@@ -26,7 +26,7 @@ import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.*;
 public class JwtProvider {
     public static final String EMPTY_SUBJECT = "";
     private final MemberRepository memberRepository;
-    private final long accessTokenExpirationTime = 1000L * 60 * 5; // 5M
+    private final long accessTokenExpirationTime = 1000L * 60 * 30; // 30M
     private final long refreshTokenExpirationTime = 1000L * 60 * 60 * 24 * 30; // 1M
     private Key key;
 

--- a/src/main/java/com/apps/pochak/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/apps/pochak/post/dto/response/PostDetailResponse.java
@@ -39,16 +39,20 @@ public class PostDetailResponse {
             final Comment recentComment
     ) {
         final Member owner = post.getOwner();
+        this.ownerId = owner.getId();
         this.ownerHandle = owner.getHandle();
         this.ownerProfileImage = owner.getProfileImage();
+
         this.tagList = tagList.stream().map(
                 TagElement::new
         ).collect(Collectors.toList());
+
         this.isFollow = isFollow;
         this.postImage = post.getPostImage();
         this.isLike = isLike;
         this.likeCount = likeCount;
         this.caption = post.getCaption();
+
         if (recentComment != null) {
             this.recentComment = CommentElement.from()
                     .comment(recentComment)

--- a/src/main/java/com/apps/pochak/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/apps/pochak/post/dto/response/PostDetailResponse.java
@@ -5,6 +5,7 @@ import com.apps.pochak.comment.dto.response.CommentElement;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.tag.domain.Tag;
+import com.apps.pochak.tag.dto.response.TagElement;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,9 +18,10 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostDetailResponse {
+    private Long ownerId;
     private String ownerHandle;
     private String ownerProfileImage;
-    private List<String> taggedMemberHandle;
+    private List<TagElement> tagList;
     private Boolean isFollow;
     private String postImage;
     private Boolean isLike;
@@ -39,8 +41,8 @@ public class PostDetailResponse {
         final Member owner = post.getOwner();
         this.ownerHandle = owner.getHandle();
         this.ownerProfileImage = owner.getProfileImage();
-        this.taggedMemberHandle = tagList.stream().map(
-                tag -> tag.getMember().getHandle()
+        this.tagList = tagList.stream().map(
+                TagElement::new
         ).collect(Collectors.toList());
         this.isFollow = isFollow;
         this.postImage = post.getPostImage();

--- a/src/main/java/com/apps/pochak/post/service/PostService.java
+++ b/src/main/java/com/apps/pochak/post/service/PostService.java
@@ -59,7 +59,7 @@ public class PostService {
         final Member loginMember = jwtProvider.getLoginMember();
         final Post post = postRepository.findPostById(postId, loginMember);
         final List<Tag> tagList = tagRepository.findTagsByPost(post);
-        if (post.isPrivate() && !isAccessAuthorized(post, tagList, loginMember)) {
+        if (post.isPrivate()) {
             throw new GeneralException(PRIVATE_POST);
         }
         final Boolean isFollow = post.isOwner(loginMember) ?
@@ -76,16 +76,6 @@ public class PostService {
                 .likeCount(likeCount)
                 .recentComment(comment)
                 .build();
-    }
-
-    private boolean isAccessAuthorized(final Post post,
-                                       final List<Tag> tagList,
-                                       final Member loginMember) {
-        final List<String> taggedMemberHandleList = tagList.stream()
-                .map(
-                        tag -> tag.getMember().getHandle()
-                ).collect(Collectors.toList());
-        return post.isOwner(loginMember) || taggedMemberHandleList.contains(loginMember.getHandle());
     }
 
     public void savePost(final PostUploadRequest request) {

--- a/src/main/java/com/apps/pochak/tag/dto/response/TagElement.java
+++ b/src/main/java/com/apps/pochak/tag/dto/response/TagElement.java
@@ -2,27 +2,23 @@ package com.apps.pochak.tag.dto.response;
 
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.tag.domain.Tag;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class TagElement {
     private Long memberId;
+    private String profileImage;
     private String handle;
     private String name;
-
-    @Builder
-    public TagElement(Long memberId, String handle, String name) {
-        this.memberId = memberId;
-        this.handle = handle;
-        this.name = name;
-    }
 
     public TagElement(Tag tag) {
         Member member = tag.getMember();
         this.memberId = member.getId();
+        this.profileImage = member.getProfileImage();
         this.handle = member.getHandle();
         this.name = member.getName();
     }

--- a/src/test/java/com/apps/pochak/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/com/apps/pochak/alarm/controller/AlarmControllerTest.java
@@ -197,6 +197,7 @@ class AlarmControllerTest {
                                         fieldWithPath("result.ownerProfileImage").type(STRING).description("포착한 유저의 프로필 이미지"),
                                         fieldWithPath("result.tagList").type(ARRAY).description("태그된 리스트"),
                                         fieldWithPath("result.tagList[].memberId").type(NUMBER).description("태그된 리스트 | 유저 아이디"),
+                                        fieldWithPath("result.tagList[].profileImage").type(STRING).description("태그된 리스트 | 유저 프로필 이미지"),
                                         fieldWithPath("result.tagList[].handle").type(STRING).description("태그된 리스트 | 유저 핸들"),
                                         fieldWithPath("result.tagList[].name").type(STRING).description("태그된 리스트 | 유저 이름"),
                                         fieldWithPath("result.postImage").type(STRING).description("게시물 미리보기 이미지")

--- a/src/test/java/com/apps/pochak/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/apps/pochak/comment/controller/CommentControllerTest.java
@@ -73,7 +73,7 @@ class CommentControllerTest {
                                 requestHeaders(
                                         headerWithName("Authorization")
                                                 .description(
-                                                        "Basic auth credentials  \n" +
+                                                        "Basic auth credentials " +
                                                                 ": 만약 아직 공개된 게시물이 아니라면 (댓글이 당연히 없으므로) 오류가 발생합니다."
                                                 )
                                 ),
@@ -91,113 +91,92 @@ class CommentControllerTest {
                                         fieldWithPath("result.parentCommentPageInfo").type(OBJECT).description("부모 댓글 페이징 정보"),
                                         fieldWithPath("result.parentCommentPageInfo.lastPage").type(BOOLEAN)
                                                 .description(
-                                                        "부모 댓글 페이징 정보 \n" +
-                                                                ": 현재 페이지가 마지막 페이지인지의 여부"
+                                                        "부모 댓글 페이징 정보: 현재 페이지가 마지막 페이지인지의 여부"
                                                 ),
                                         fieldWithPath("result.parentCommentPageInfo.totalPages").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 페이징 정보 \n" +
-                                                                ": 총 페이지 수"
+                                                        "부모 댓글 페이징 정보: 총 페이지 수"
                                                 ),
                                         fieldWithPath("result.parentCommentPageInfo.totalElements").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 페이징 정보 \n" +
-                                                                ": 총 부모 댓글의 수"
+                                                        "부모 댓글 페이징 정보: 총 부모 댓글의 수"
                                                 ),
                                         fieldWithPath("result.parentCommentPageInfo.size").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 페이징 정보 \n" +
-                                                                ": 페이징 사이즈"
+                                                        "부모 댓글 페이징 정보: 페이징 사이즈"
                                                 ),
                                         fieldWithPath("result.parentCommentList").type(ARRAY).description("부모 댓글 리스트"),
                                         fieldWithPath("result.parentCommentList[].commentId").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 댓글 아이디"
+                                                        "부모 댓글 리스트 | 댓글 아이디"
+                                                ).optional(),
+                                        fieldWithPath("result.parentCommentList[].memberId").type(NUMBER)
+                                                .description(
+                                                        "부모 댓글 리스트 | 작성자 아이디"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].profileImage").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 작성자 프로필 사진"
+                                                        "부모 댓글 리스트 | 작성자 프로필 사진"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].handle").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 작성자 아이디"
+                                                        "부모 댓글 리스트 | 작성자 핸들 (handle)"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].createdDate").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 댓글 작성 시간"
+                                                        "부모 댓글 리스트 | 댓글 작성 시간"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].content").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 댓글 내용"
+                                                        "부모 댓글 리스트 | 댓글 내용"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentPageInfo").type(OBJECT)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 페이징 정보"
+                                                        "부모 댓글 리스트 | 자식 댓글 페이징 정보"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentPageInfo.lastPage").type(BOOLEAN)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 페이징 정보 \n" +
-                                                                ": 현재 페이지가 마지막 페이지인지의 여부"
+                                                        "부모 댓글 리스트 | 자식 댓글 페이징 정보 | 현재 페이지가 마지막 페이지인지의 여부"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentPageInfo.totalPages").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 페이징 정보 \n" +
-                                                                ": 총 페이지 수"
+                                                        "부모 댓글 리스트 | 자식 댓글 페이징 정보 | 총 페이지 수"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentPageInfo.totalElements").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 페이징 정보 \n" +
-                                                                ": 총 자식 댓글의 수"
+                                                        "부모 댓글 리스트 | 자식 댓글 페이징 정보 | 총 자식 댓글의 수"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentPageInfo.size").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 페이징 정보 \n" +
-                                                                ": 페이징 사이즈"
+                                                        "부모 댓글 리스트 | 자식 댓글 페이징 정보 | 페이징 사이즈"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentList").type(ARRAY)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 리스트"
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentList[].commentId").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 리스트 \n" +
-                                                                ": 자식 댓글 아이디"
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트 | 자식 댓글 아이디"
+                                                ).optional(),
+                                        fieldWithPath("result.parentCommentList[].childCommentList[].memberId").type(NUMBER)
+                                                .description(
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트 | 작성자 아이디"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentList[].profileImage").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 리스트 \n" +
-                                                                ": 작성자 프로필 사진"
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트 | 작성자 프로필 이미지"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentList[].handle").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 리스트 \n" +
-                                                                ": 작성자 아이디"
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트 | 작성자 핸들"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentList[].createdDate").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 리스트 \n" +
-                                                                ": 댓글 작성 시간"
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트 | 댓글 작성 시간"
                                                 ).optional(),
                                         fieldWithPath("result.parentCommentList[].childCommentList[].content").type(STRING)
                                                 .description(
-                                                        "부모 댓글 리스트 \n" +
-                                                                ": 자식 댓글 리스트 \n" +
-                                                                ": 댓글 내용"
+                                                        "부모 댓글 리스트 | 자식 댓글 리스트 | 댓글 내용"
                                                 ).optional(),
                                         fieldWithPath("result.loginMemberProfileImage").type(STRING)
                                                 .description(
@@ -225,7 +204,7 @@ class CommentControllerTest {
                                 requestHeaders(
                                         headerWithName("Authorization")
                                                 .description(
-                                                        "Basic auth credentials  \n" +
+                                                        "Basic auth credentials " +
                                                                 ": 만약 아직 공개된 게시물이 아니라면 (댓글이 당연히 없으므로) 오류가 발생합니다."
                                                 )
                                 ),
@@ -245,13 +224,17 @@ class CommentControllerTest {
                                                 .description(
                                                         "부모 댓글 아이디"
                                                 ).optional(),
+                                        fieldWithPath("result.memberId").type(NUMBER)
+                                                .description(
+                                                        "부모 댓글 작성자 아이디"
+                                                ).optional(),
                                         fieldWithPath("result.profileImage").type(STRING)
                                                 .description(
                                                         "부모 댓글 작성자 프로필 사진"
                                                 ).optional(),
                                         fieldWithPath("result.handle").type(STRING)
                                                 .description(
-                                                        "부모 댓글 작성자 아이디"
+                                                        "부모 댓글 작성자 핸들"
                                                 ).optional(),
                                         fieldWithPath("result.createdDate").type(STRING)
                                                 .description(
@@ -267,23 +250,19 @@ class CommentControllerTest {
                                                 ).optional(),
                                         fieldWithPath("result.childCommentPageInfo.lastPage").type(BOOLEAN)
                                                 .description(
-                                                        "자식 댓글 페이징 정보 \n" +
-                                                                ": 현재 페이지가 마지막 페이지인지의 여부"
+                                                        "자식 댓글 페이징 정보 | 현재 페이지가 마지막 페이지인지의 여부"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentPageInfo.totalPages").type(NUMBER)
                                                 .description(
-                                                        "자식 댓글 페이징 정보 \n" +
-                                                                ": 총 페이지 수"
+                                                        "자식 댓글 페이징 정보 | 총 페이지 수"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentPageInfo.totalElements").type(NUMBER)
                                                 .description(
-                                                        "자식 댓글 페이징 정보 \n" +
-                                                                ": 총 자식 댓글의 수"
+                                                        "자식 댓글 페이징 정보 | 총 자식 댓글의 수"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentPageInfo.size").type(NUMBER)
                                                 .description(
-                                                        "자식 댓글 페이징 정보 \n" +
-                                                                ": 페이징 사이즈"
+                                                        "자식 댓글 페이징 정보 | 페이징 사이즈"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentList").type(ARRAY)
                                                 .description(
@@ -291,28 +270,27 @@ class CommentControllerTest {
                                                 ).optional(),
                                         fieldWithPath("result.childCommentList[].commentId").type(NUMBER)
                                                 .description(
-                                                        "자식 댓글 리스트 \n" +
-                                                                ": 자식 댓글 아이디"
+                                                        "자식 댓글 리스트 | 자식 댓글 아이디"
+                                                ).optional(),
+                                        fieldWithPath("result.childCommentList[].memberId").type(NUMBER)
+                                                .description(
+                                                        "자식 댓글 리스트 | 작성자 아이디"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentList[].profileImage").type(STRING)
                                                 .description(
-                                                        "자식 댓글 리스트 \n" +
-                                                                ": 작성자 프로필 사진"
+                                                        "자식 댓글 리스트 | 작성자 프로필 사진"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentList[].handle").type(STRING)
                                                 .description(
-                                                        "자식 댓글 리스트 \n" +
-                                                                ": 작성자 아이디"
+                                                        "자식 댓글 리스트 | 작성자 핸들"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentList[].createdDate").type(STRING)
                                                 .description(
-                                                        "자식 댓글 리스트 \n" +
-                                                                ": 댓글 작성 시간"
+                                                        "자식 댓글 리스트 | 댓글 작성 시간"
                                                 ).optional(),
                                         fieldWithPath("result.childCommentList[].content").type(STRING)
                                                 .description(
-                                                        "자식 댓글 리스트 \n" +
-                                                                ": 댓글 내용"
+                                                        "자식 댓글 리스트 | 댓글 내용"
                                                 ).optional()
                                 )
 
@@ -341,7 +319,7 @@ class CommentControllerTest {
                                 requestHeaders(
                                         headerWithName("Authorization")
                                                 .description(
-                                                        "Basic auth credentials  \n" +
+                                                        "Basic auth credentials  " +
                                                                 ": 만약 아직 공개된 게시물이 아니라면 오류가 발생합니다."
                                                 )
                                 ),
@@ -352,7 +330,7 @@ class CommentControllerTest {
                                         fieldWithPath("content").type(STRING).description("댓글 내용"),
                                         fieldWithPath("parentCommentId").type(NUMBER)
                                                 .description(
-                                                        "부모 댓글 아이디: \n" +
+                                                        "부모 댓글 아이디: " +
                                                                 "만약 자식 댓글을 작성하고 싶은 경우 부모 댓글 아이디를 전달하고, " +
                                                                 "부모 댓글을 작성하고 싶은 경우 null값으로 전달합니다."
                                                 ).optional()

--- a/src/test/java/com/apps/pochak/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/apps/pochak/like/controller/LikeControllerTest.java
@@ -117,8 +117,10 @@ public class LikeControllerTest {
                                         fieldWithPath("message").type(STRING).description("결과 메세지"),
                                         fieldWithPath("result").type(OBJECT).description("결과 데이터"),
                                         fieldWithPath("result.likeMembersList").description("좋아요를 누른 사람들의 리스트").type(ARRAY),
+                                        fieldWithPath("result.likeMembersList[].memberId").type(NUMBER)
+                                                .description("유저 아이디").optional(),
                                         fieldWithPath("result.likeMembersList[].handle").type(STRING)
-                                                .description("유저 닉네임").optional(),
+                                                .description("유저 핸들").optional(),
                                         fieldWithPath("result.likeMembersList[].profileImage").type(STRING)
                                                 .description("프로필 이미지 url").optional(),
                                         fieldWithPath("result.likeMembersList[].name").type(STRING)

--- a/src/test/java/com/apps/pochak/post/controller/PostControllerTest.java
+++ b/src/test/java/com/apps/pochak/post/controller/PostControllerTest.java
@@ -245,9 +245,14 @@ class PostControllerTest {
                                         fieldWithPath("code").type(STRING).description("결과 코드"),
                                         fieldWithPath("message").type(STRING).description("결과 메세지"),
                                         fieldWithPath("result").type(OBJECT).description("결과 데이터"),
-                                        fieldWithPath("result.ownerHandle").type(STRING).description("게시자 아이디 (handle)"),
+                                        fieldWithPath("result.ownerId").type(NUMBER).description("게시자 아이디"),
+                                        fieldWithPath("result.ownerHandle").type(STRING).description("게시자 핸들 (handle)"),
                                         fieldWithPath("result.ownerProfileImage").type(STRING).description("게시자 프로필 이미지"),
-                                        fieldWithPath("result.taggedMemberHandle").type(ARRAY).description("태그된 유저들의 아이디"),
+                                        fieldWithPath("result.tagList").type(ARRAY).description("태그된 유저 리스트"),
+                                        fieldWithPath("result.tagList[].memberId").type(NUMBER).description("태그된 리스트 | 유저 아이디"),
+                                        fieldWithPath("result.tagList[].profileImage").type(STRING).description("태그된 리스트 | 유저 프로필 이미지"),
+                                        fieldWithPath("result.tagList[].handle").type(STRING).description("태그된 리스트 | 유저 핸들"),
+                                        fieldWithPath("result.tagList[].name").type(STRING).description("태그된 리스트 | 유저 이름"),
                                         fieldWithPath("result.isFollow").type(BOOLEAN)
                                                 .description(
                                                         "현재 로그인한 유저가 게시자를 팔로우하고 있는지 여부 \n" +
@@ -268,13 +273,17 @@ class PostControllerTest {
                                                 .description(
                                                         "게시물의 가장 최근 댓글 : 댓글 아이디"
                                                 ).optional(),
+                                        fieldWithPath("result.recentComment.memberId").type(NUMBER)
+                                                .description(
+                                                        "게시물의 가장 최근 댓글 : 댓글 작성자 아이디"
+                                                ).optional(),
                                         fieldWithPath("result.recentComment.profileImage").type(STRING)
                                                 .description(
                                                         "게시물의 가장 최근 댓글 : 댓글 게시자의 프로필 이미지"
                                                 ).optional(),
                                         fieldWithPath("result.recentComment.handle").type(STRING)
                                                 .description(
-                                                        "게시물의 가장 최근 댓글 : 댓글 게시자의 아이디 (handle)"
+                                                        "게시물의 가장 최근 댓글 : 댓글 게시자의 핸들 (handle)"
                                                 ).optional(),
                                         fieldWithPath("result.recentComment.createdDate").type(STRING)
                                                 .description(


### PR DESCRIPTION
## 📒 개요

태그된 유저 조회, 태그 수 제한 validation 과정 추가

## 📍 Issue 번호

> #26 

## 🛠️ 작업사항

- 태그된 유저 조회에서 추가 정보 전달
- 태그된 유저 최대 수 제한

## 🧰 변경로직

- 이제 최대 5명의 유저만 태그 가능함
