### PR TITLE
[refactor/#67-postrepo-querydsl] PostCustomRepository - `findPostByIdWithoutBlockPost()` 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ application-API-KEY.tar
 application-OAUTH.tar
 application-JWT.tar
 
+### Qclass ###
+/src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM openjdk:17-jdk
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 3000
-ENV SPRING_PROFILES_ACTIVE=DEV
+ARG SPRING_PROFILES_ACTIVE
+ENV SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-DEV}
 
 CMD java -jar -Duser.timezone=Asia/Seoul app.jar

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok:1.18.34'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
 
     implementation 'com.h2database:h2'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -132,5 +132,4 @@ tasks.withType(JavaCompile) {
 
 sourceSets {
     main.java.srcDirs += "$projectDir/build/generated"
-    print "$projectDir"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test"){
-      exclude group: "com.vaadin.external.google", module:"android-json"
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude group: "com.vaadin.external.google", module: "android-json"
     }
 
     testImplementation 'org.springframework.security:spring-security-test'
@@ -63,6 +63,12 @@ dependencies {
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.30.1'
 
     implementation group: 'org.json', name: 'json', version: '20090211'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 ext {
@@ -108,7 +114,21 @@ jar {
     enabled = false
 }
 
-
 build {
     dependsOn copyDocument
+}
+
+def generated = 'src/main/generated'
+
+clean {
+    delete file(generated)
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(generated)
+}
+
+sourceSets {
+    main.java.srcDirs += "$projectDir/build/generated"
+    print "$projectDir"
 }

--- a/src/main/java/com/apps/pochak/comment/service/CommentService.java
+++ b/src/main/java/com/apps/pochak/comment/service/CommentService.java
@@ -44,7 +44,7 @@ public class CommentService {
             final Pageable pageable
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
-        final Post post = postRepository.findPublicPostById(postId, loginMember);
+        final Post post = postRepository.findPublicPostById(postId);
         final Page<Comment> commentList = commentRepository.findParentCommentByPost(post, loginMember, pageable);
         return new CommentElements(loginMember, commentList);
     }
@@ -68,7 +68,7 @@ public class CommentService {
             final CommentUploadRequest request
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
-        final Post post = postRepository.findPublicPostById(postId, loginMember);
+        final Post post = postRepository.findPublicPostById(postId);
 
         if (request.checkChildComment()) {
             saveChildComment(

--- a/src/main/java/com/apps/pochak/global/api_payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/apps/pochak/global/api_payload/code/status/ErrorStatus.java
@@ -6,8 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import java.security.NoSuchAlgorithmException;
-
 import static org.springframework.http.HttpStatus.*;
 
 @Getter
@@ -78,6 +76,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EXCEED_TAG_LIMIT(BAD_REQUEST, "POST4004", "최대 멤버 태그 수를 초과하였습니다."),
     TAGGED_ONESELF(BAD_REQUEST, "POST4005", "자기 자신을 태그하였습니다."),
     INVALID_TAG_INFO(BAD_REQUEST, "POST4006", "태그된 멤버의 정보가 확인되지 않습니다."),
+    BLOCKED_POST(BAD_REQUEST, "POST4007", "확인할 수 없는 게시물입니다."),
 
     // Tag
     INVALID_TAG_ID(BAD_REQUEST, "TAG4001", "유효하지 않은 태그 아이디입니다."),

--- a/src/main/java/com/apps/pochak/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/apps/pochak/global/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package com.apps.pochak.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/apps/pochak/global/config/QuerydslConfig.java
+++ b/src/main/java/com/apps/pochak/global/config/QuerydslConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
-public class QueryDSLConfig {
+public class QuerydslConfig {
     private final EntityManager entityManager;
 
     @Bean

--- a/src/main/java/com/apps/pochak/like/service/LikeService.java
+++ b/src/main/java/com/apps/pochak/like/service/LikeService.java
@@ -34,7 +34,7 @@ public class LikeService {
             final Long postId
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
-        final Post post = postRepository.findPostById(postId, loginMember);
+        final Post post = postRepository.findPostById(postId);
 
         final Optional<LikeEntity> optionalLike = likeRepository.findByLikeMemberAndLikedPost(loginMember, post);
         if (optionalLike.isPresent()) {
@@ -76,7 +76,7 @@ public class LikeService {
             final Long postId
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
-        final Post likedPost = postRepository.findPostById(postId, loginMember);
+        final Post likedPost = postRepository.findPostById(postId);
 
         final List<LikeElement> likeElements = likeRepository.findLikesAndIsFollow(
                 loginMember.getId(),

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -49,16 +49,12 @@ public class PostCustomRepository {
         );
     }
 
-    private BooleanExpression checkOwnerOrTaggedMemberBlockLoginMember(
-            final Long loginMemberId
-    ) {
+    private BooleanExpression checkOwnerOrTaggedMemberBlockLoginMember(final Long loginMemberId) {
         return (block.blocker.eq(tag.member).or(block.blocker.eq(post.owner)))
                 .and(block.blockedMember.id.eq(loginMemberId));
     }
 
-    private BooleanExpression checkLoginMemberBlockOwnerOrTaggedMember(
-            final Long loginMemberId
-    ) {
+    private BooleanExpression checkLoginMemberBlockOwnerOrTaggedMember(final Long loginMemberId) {
         return (block.blocker.id.eq(loginMemberId))
                 .and(block.blockedMember.eq(tag.member).or(block.blockedMember.eq(post.owner)));
     }

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 import static com.apps.pochak.block.domain.QBlock.block;
-import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.INVALID_POST_ID;
+import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
 import static com.apps.pochak.post.domain.QPost.post;
 import static com.apps.pochak.tag.domain.QTag.tag;
 
@@ -24,7 +24,7 @@ public class PostCustomRepository {
             final Long postId,
             final Long loginMemberId
     ) {
-        return findByIdWithoutBlockPost(postId, loginMemberId).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
+        return findByIdWithoutBlockPost(postId, loginMemberId).orElseThrow(() -> new GeneralException(BLOCKED_POST));
     }
 
     public Optional<Post> findByIdWithoutBlockPost(

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -1,0 +1,65 @@
+package com.apps.pochak.post.domain.repository;
+
+import com.apps.pochak.global.BaseEntityStatus;
+import com.apps.pochak.global.api_payload.exception.GeneralException;
+import com.apps.pochak.post.domain.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.apps.pochak.block.domain.QBlock.block;
+import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.INVALID_POST_ID;
+import static com.apps.pochak.post.domain.QPost.post;
+import static com.apps.pochak.tag.domain.QTag.tag;
+
+@Repository
+@RequiredArgsConstructor
+public class PostCustomRepository {
+    private final JPAQueryFactory query;
+
+    public Post findPostByIdWithoutBlockPost(
+            final Long postId,
+            final Long loginMemberId
+    ) {
+        return findByIdWithoutBlockPost(postId, loginMemberId).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
+    }
+
+    public Optional<Post> findByIdWithoutBlockPost(
+            final Long postId,
+            final Long loginMemberId
+    ) {
+        return Optional.ofNullable(
+                query.selectFrom(post)
+                        .distinct()
+                        .join(post.owner).fetchJoin()
+                        .join(tag).on(tag.post.eq(post))
+                        .leftJoin(block).on(
+                                checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
+                                        .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
+                        )
+                        .where(
+                                post.id.eq(postId),
+                                post.status.eq(BaseEntityStatus.ACTIVE),
+                                block.isNull()
+                        )
+                        .fetchOne()
+        );
+    }
+
+    private BooleanExpression checkOwnerOrTaggedMemberBlockLoginMember(
+            final Long loginMemberId
+    ) {
+        return (block.blocker.eq(tag.member).or(block.blocker.eq(post.owner)))
+                .and(block.blockedMember.id.eq(loginMemberId));
+    }
+
+    private BooleanExpression checkLoginMemberBlockOwnerOrTaggedMember(
+            final Long loginMemberId
+    ) {
+        return (block.blocker.id.eq(loginMemberId))
+                .and(block.blockedMember.eq(tag.member).or(block.blockedMember.eq(post.owner)));
+    }
+}

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -33,17 +33,17 @@ public class PostCustomRepository {
     ) {
         return Optional.ofNullable(
                 query.selectFrom(post)
-                        .distinct()
                         .join(post.owner).fetchJoin()
                         .join(tag).on(tag.post.eq(post))
                         .leftJoin(block).on(
                                 checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
                                         .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
                         )
+                        .groupBy(post)
+                        .having(block.id.count().eq(0L))
                         .where(
                                 post.id.eq(postId),
-                                post.status.eq(BaseEntityStatus.ACTIVE),
-                                block.isNull()
+                                post.status.eq(BaseEntityStatus.ACTIVE)
                         )
                         .fetchOne()
         );

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
@@ -21,32 +21,18 @@ import static com.apps.pochak.global.converter.LongListToStringConverter.convert
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("""
-            select p from Post p
-            join fetch p.owner
-            where p.id = :postId and p.status = 'ACTIVE'
-                and p.owner not in (select b.blockedMember from Block b where b.blocker = :loginMember)
-                and :loginMember not in (select b.blockedMember from Block b where b.blocker = p.owner)
-                and not exists (select t.member from Tag t where t.post = p intersect select b.blockedMember from Block b where b.blocker = :loginMember)
-                and :loginMember not in (select b.blockedMember from Block b where b.blocker in (select t.member from Tag t where t.post = p))
-            """)
-    Optional<Post> findById(
-            @Param("postId") final Long postId,
-            @Param("loginMember") final Member loginMember
-    );
+    Optional<Post> findById(final Long id);
 
     default Post findPostById(
-            final Long postId,
-            final Member loginMember
+            final Long postId
     ) {
-        return findById(postId, loginMember).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
+        return findById(postId).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
     }
 
     default Post findPublicPostById(
-            final Long postId,
-            final Member loginMember
+            final Long postId
     ) {
-        final Post post = findById(postId, loginMember).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
+        final Post post = findById(postId).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
         if (post.isPrivate()) {
             throw new GeneralException(PRIVATE_POST);
         }

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
@@ -23,15 +23,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findById(final Long id);
 
-    default Post findPostById(
-            final Long postId
-    ) {
+    default Post findPostById(final Long postId) {
         return findById(postId).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
     }
 
-    default Post findPublicPostById(
-            final Long postId
-    ) {
+    default Post findPublicPostById(final Long postId) {
         final Post post = findById(postId).orElseThrow(() -> new GeneralException(INVALID_POST_ID));
         if (post.isPrivate()) {
             throw new GeneralException(PRIVATE_POST);

--- a/src/main/java/com/apps/pochak/post/service/PostService.java
+++ b/src/main/java/com/apps/pochak/post/service/PostService.java
@@ -14,6 +14,7 @@ import com.apps.pochak.like.domain.repository.LikeRepository;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.post.domain.repository.PostCustomRepository;
 import com.apps.pochak.post.domain.repository.PostRepository;
 import com.apps.pochak.post.dto.PostElements;
 import com.apps.pochak.post.dto.request.PostUploadRequest;
@@ -38,6 +39,7 @@ import static com.apps.pochak.global.s3.DirName.POST;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final PostCustomRepository postCustomRepository;
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final TagRepository tagRepository;
@@ -66,7 +68,7 @@ public class PostService {
             final Long postId
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
-        final Post post = postRepository.findPostById(postId, loginMember);
+        final Post post = postCustomRepository.findPostByIdWithoutBlockPost(postId, accessor.getMemberId());
         final List<Tag> tagList = tagRepository.findTagsByPost(post);
         if (post.isPrivate()) {
             throw new GeneralException(PRIVATE_POST);

--- a/src/main/java/com/apps/pochak/report/service/ReportService.java
+++ b/src/main/java/com/apps/pochak/report/service/ReportService.java
@@ -27,7 +27,7 @@ public class ReportService {
             final ReportUploadRequest request
     ) {
         final Member reporter = memberRepository.findMemberById(accessor.getMemberId());
-        final Post reportedPost = postRepository.findPostById(request.getPostId(), reporter);
+        final Post reportedPost = postRepository.findPostById(request.getPostId());
 
         Report report = request.toEntity(reporter, reportedPost);
         reportRepository.save(report);

--- a/src/main/java/com/apps/pochak/tag/domain/repository/TagRepository.java
+++ b/src/main/java/com/apps/pochak/tag/domain/repository/TagRepository.java
@@ -97,14 +97,11 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     Long countByPost_PostStatusAndPost_OwnerAndMember(PostStatus postStatus, Member owner, Member member);
 
     @Query("""
-    select count(t) from Tag t
-    join t.member m
-    join t.post p
-    where p.postStatus = 'PUBLIC'
-    and p.status = 'ACTIVE'
-    and ((m = :member and p.owner = :loginMember)
-    or (m = :loginMember and p.owner = :member))
-    order by p.allowedDate desc
+    select count(t1) from Tag t1
+    join Tag t2 on t1.post = t2.post
+    where t1.post.postStatus = 'PUBLIC'
+    and t1.post.status = 'ACTIVE'
+    and (t1.member = :loginMember and t2.member = :member)
     """)
     Long countByMember(@Param("loginMember") Member loginMember, @Param("member")Member member);
 }

--- a/src/test/java/com/apps/pochak/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/com/apps/pochak/alarm/controller/AlarmControllerTest.java
@@ -1,6 +1,7 @@
 package com.apps.pochak.alarm.controller;
 
 import com.apps.pochak.alarm.domain.Alarm;
+import com.apps.pochak.alarm.domain.TagAlarm;
 import com.apps.pochak.alarm.dto.response.AlarmElements;
 import com.apps.pochak.alarm.service.AlarmService;
 import com.apps.pochak.auth.domain.Accessor;
@@ -24,8 +25,8 @@ import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.api_payload.code.status.SuccessStatus.SUCCESS_CHECK_ALARM;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.tag.fixture.TagFixture.WAITING_TAG;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.tag.fixture.TagFixture.STATIC_WAITING_TAG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -45,13 +46,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @MockBean(JpaMetamodelMappingContext.class)
 class AlarmControllerTest extends ControllerTest {
 
-    private static final Member MEMBER = MEMBER1;
+    private static final Member MEMBER = STATIC_MEMBER1;
+    private static final TagAlarm TAG_ALARM = STATIC_TAG_ALARM;
 
     private static final List<Alarm> ALARM_LIST = List.of(
-            COMMENT_REPLY_ALARM,
-            FOLLOW_ALARM,
-            TAGGED_LIKE_ALARM,
-            TAG_ALARM
+            STATIC_COMMENT_REPLY_ALARM,
+            STATIC_FOLLOW_ALARM,
+            STATIC_TAGGED_LIKE_ALARM,
+            STATIC_TAG_ALARM
     );
 
     @MockBean
@@ -184,7 +186,7 @@ class AlarmControllerTest extends ControllerTest {
 
         when(postService.getPreviewPost(any(), any()))
                 .thenReturn(
-                        new PostPreviewResponse(TAG_ALARM.getTag().getPost(), List.of(WAITING_TAG))
+                        new PostPreviewResponse(TAG_ALARM.getTag().getPost(), List.of(STATIC_WAITING_TAG))
                 );
 
         this.mockMvc.perform(

--- a/src/test/java/com/apps/pochak/alarm/fixture/AlarmFixture.java
+++ b/src/test/java/com/apps/pochak/alarm/fixture/AlarmFixture.java
@@ -7,39 +7,39 @@ import com.apps.pochak.alarm.domain.TagAlarm;
 
 import static com.apps.pochak.alarm.domain.AlarmType.COMMENT_REPLY;
 import static com.apps.pochak.alarm.domain.AlarmType.OWNER_LIKE;
-import static com.apps.pochak.comment.fixture.CommentFixture.CHILD_COMMENT;
-import static com.apps.pochak.follow.fixture.FollowFixture.RECEIVE_FOLLOW;
-import static com.apps.pochak.like.fixture.LikeFixture.LIKE2;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
-import static com.apps.pochak.tag.fixture.TagFixture.WAITING_TAG;
+import static com.apps.pochak.comment.fixture.CommentFixture.STATIC_CHILD_COMMENT;
+import static com.apps.pochak.follow.fixture.FollowFixture.STATIC_RECEIVE_FOLLOW;
+import static com.apps.pochak.like.fixture.LikeFixture.STATIC_LIKE2;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
+import static com.apps.pochak.tag.fixture.TagFixture.STATIC_WAITING_TAG;
 
 public class AlarmFixture {
 
-    public static final CommentAlarm COMMENT_REPLY_ALARM = new CommentAlarm(
+    public static final CommentAlarm STATIC_COMMENT_REPLY_ALARM = new CommentAlarm(
             1L,
-            CHILD_COMMENT,
-            MEMBER1,
+            STATIC_CHILD_COMMENT,
+            STATIC_MEMBER1,
             COMMENT_REPLY
     );
 
-    public static final FollowAlarm FOLLOW_ALARM = new FollowAlarm(
+    public static final FollowAlarm STATIC_FOLLOW_ALARM = new FollowAlarm(
             2L,
-            RECEIVE_FOLLOW,
-            MEMBER1
+            STATIC_RECEIVE_FOLLOW,
+            STATIC_MEMBER1
     );
 
-    public static final LikeAlarm TAGGED_LIKE_ALARM = new LikeAlarm(
+    public static final LikeAlarm STATIC_TAGGED_LIKE_ALARM = new LikeAlarm(
             3L,
-            LIKE2,
-            MEMBER1,
+            STATIC_LIKE2,
+            STATIC_MEMBER1,
             OWNER_LIKE
     );
 
-    public static final TagAlarm TAG_ALARM = new TagAlarm(
-        4L,
-            WAITING_TAG,
-            MEMBER2,
-            MEMBER1
+    public static final TagAlarm STATIC_TAG_ALARM = new TagAlarm(
+            4L,
+            STATIC_WAITING_TAG,
+            STATIC_MEMBER2,
+            STATIC_MEMBER1
     );
 }

--- a/src/test/java/com/apps/pochak/block/controller/BlockControllerTest.java
+++ b/src/test/java/com/apps/pochak/block/controller/BlockControllerTest.java
@@ -5,6 +5,7 @@ import com.apps.pochak.block.domain.Block;
 import com.apps.pochak.block.dto.response.BlockElements;
 import com.apps.pochak.block.service.BlockService;
 import com.apps.pochak.global.ControllerTest;
+import com.apps.pochak.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,12 +17,12 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import java.util.List;
 
-import static com.apps.pochak.block.fixture.BlockFixture.BLOCK;
+import static com.apps.pochak.block.fixture.BlockFixture.STATIC_BLOCK;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -41,8 +42,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @MockBean(JpaMetamodelMappingContext.class)
 class BlockControllerTest extends ControllerTest {
 
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Member MEMBER2 = STATIC_MEMBER2;
+
     private static final List<Block> BLOCK_LIST = List.of(
-            BLOCK
+            STATIC_BLOCK
     );
 
     @MockBean

--- a/src/test/java/com/apps/pochak/block/fixture/BlockFixture.java
+++ b/src/test/java/com/apps/pochak/block/fixture/BlockFixture.java
@@ -2,14 +2,13 @@ package com.apps.pochak.block.fixture;
 
 import com.apps.pochak.block.domain.Block;
 
-import static com.apps.pochak.member.fixture.MemberFixture.BLOCKED_MEMBER;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
 
 public class BlockFixture {
 
-    public static final Block BLOCK = new Block(
+    public static final Block STATIC_BLOCK = new Block(
             1L,
-            MEMBER1,
-            BLOCKED_MEMBER
+            STATIC_MEMBER1,
+            STATIC_MEMBER1
     );
 }

--- a/src/test/java/com/apps/pochak/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/apps/pochak/comment/controller/CommentControllerTest.java
@@ -7,6 +7,7 @@ import com.apps.pochak.comment.dto.response.CommentElements;
 import com.apps.pochak.comment.dto.response.ParentCommentElement;
 import com.apps.pochak.comment.service.CommentService;
 import com.apps.pochak.global.ControllerTest;
+import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.post.domain.Post;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,12 +22,12 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import java.util.List;
 
-import static com.apps.pochak.comment.fixture.CommentFixture.PARENT_COMMENT;
+import static com.apps.pochak.comment.fixture.CommentFixture.STATIC_PARENT_COMMENT;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -45,10 +46,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @MockBean(JpaMetamodelMappingContext.class)
 class CommentControllerTest extends ControllerTest {
 
-    private static final Post POST = PUBLIC_POST;
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Post POST = STATIC_PUBLIC_POST;
+    private static final Comment PARENT_COMMENT = STATIC_PARENT_COMMENT;
 
     private static final List<Comment> PARENT_COMMENT_LIST = List.of(
-            PARENT_COMMENT
+            STATIC_PARENT_COMMENT
     );
 
     @MockBean

--- a/src/test/java/com/apps/pochak/comment/fixture/CommentFixture.java
+++ b/src/test/java/com/apps/pochak/comment/fixture/CommentFixture.java
@@ -2,24 +2,23 @@ package com.apps.pochak.comment.fixture;
 
 import com.apps.pochak.comment.domain.Comment;
 
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 
 public class CommentFixture {
 
-    public static final Comment PARENT_COMMENT = new Comment(
+    public static final Comment STATIC_PARENT_COMMENT = new Comment(
             1L,
             "부모 댓글입니다.",
-            MEMBER1,
-            PUBLIC_POST
+            STATIC_MEMBER1,
+            STATIC_PUBLIC_POST
     );
 
-    public static final Comment CHILD_COMMENT = new Comment(
+    public static final Comment STATIC_CHILD_COMMENT = new Comment(
             2L,
             "자식 댓글입니다.",
-            MEMBER2,
-            PUBLIC_POST,
-            PARENT_COMMENT
+            STATIC_MEMBER1,
+            STATIC_PUBLIC_POST,
+            STATIC_PARENT_COMMENT
     );
 }

--- a/src/test/java/com/apps/pochak/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/apps/pochak/follow/controller/FollowControllerTest.java
@@ -22,8 +22,8 @@ import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.api_payload.code.status.SuccessStatus.SUCCESS_FOLLOW;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -42,10 +42,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(FollowController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class FollowControllerTest extends ControllerTest {
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Member MEMBER2 = STATIC_MEMBER2;
 
     private static final List<Member> MEMBER_LIST = List.of(
-            MEMBER1,
-            MEMBER2
+            STATIC_MEMBER1,
+            STATIC_MEMBER2
     );
 
     @MockBean

--- a/src/test/java/com/apps/pochak/follow/fixture/FollowFixture.java
+++ b/src/test/java/com/apps/pochak/follow/fixture/FollowFixture.java
@@ -2,19 +2,19 @@ package com.apps.pochak.follow.fixture;
 
 import com.apps.pochak.follow.domain.Follow;
 
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
 
 public class FollowFixture {
-    public static final Follow SEND_FOLLOW = new Follow(
+    public static final Follow STATIC_SEND_FOLLOW = new Follow(
             1L,
-            MEMBER1,
-            MEMBER2
+            STATIC_MEMBER1,
+            STATIC_MEMBER2
     );
 
-    public static final Follow RECEIVE_FOLLOW = new Follow(
+    public static final Follow STATIC_RECEIVE_FOLLOW = new Follow(
             2L,
-            MEMBER2,
-            MEMBER1
+            STATIC_MEMBER2,
+            STATIC_MEMBER1
     );
 }

--- a/src/test/java/com/apps/pochak/global/TestQueryDSLConfig.java
+++ b/src/test/java/com/apps/pochak/global/TestQueryDSLConfig.java
@@ -1,0 +1,24 @@
+package com.apps.pochak.global;
+
+import com.apps.pochak.post.domain.repository.PostCustomRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDSLConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public PostCustomRepository postCustomRepository() {
+        return new PostCustomRepository(jpaQueryFactory());
+    }
+}

--- a/src/test/java/com/apps/pochak/global/TestQuerydslConfig.java
+++ b/src/test/java/com/apps/pochak/global/TestQuerydslConfig.java
@@ -6,9 +6,11 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @TestConfiguration
-public class TestQueryDSLConfig {
+@EnableJpaAuditing
+public class TestQuerydslConfig {
     @PersistenceContext
     private EntityManager entityManager;
 

--- a/src/test/java/com/apps/pochak/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/apps/pochak/like/controller/LikeControllerTest.java
@@ -2,10 +2,11 @@ package com.apps.pochak.like.controller;
 
 import com.apps.pochak.auth.domain.Accessor;
 import com.apps.pochak.global.ControllerTest;
-import com.apps.pochak.like.domain.LikeEntity;
 import com.apps.pochak.like.dto.response.LikeElement;
 import com.apps.pochak.like.dto.response.LikeElements;
 import com.apps.pochak.like.service.LikeService;
+import com.apps.pochak.member.domain.Member;
+import com.apps.pochak.post.domain.Post;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,11 +22,9 @@ import java.util.List;
 
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
-import static com.apps.pochak.like.fixture.LikeFixture.LIKE1;
-import static com.apps.pochak.like.fixture.LikeFixture.LIKE2;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -45,11 +44,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(LikeController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 public class LikeControllerTest extends ControllerTest {
-
-    private static final List<LikeEntity> LIKE_LIST = List.of(
-            LIKE1,
-            LIKE2
-    );
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Member MEMBER2 = STATIC_MEMBER2;
+    private static final Post PUBLIC_POST = STATIC_PUBLIC_POST;
 
     @MockBean
     LikeService likeService;

--- a/src/test/java/com/apps/pochak/like/fixture/LikeFixture.java
+++ b/src/test/java/com/apps/pochak/like/fixture/LikeFixture.java
@@ -2,21 +2,21 @@ package com.apps.pochak.like.fixture;
 
 import com.apps.pochak.like.domain.LikeEntity;
 
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 
 public class LikeFixture {
 
-    public static final LikeEntity LIKE1 = new LikeEntity(
+    public static final LikeEntity STATIC_LIKE1 = new LikeEntity(
             1L,
-            MEMBER1,
-            PUBLIC_POST
+            STATIC_MEMBER1,
+            STATIC_PUBLIC_POST
     );
 
-    public static final LikeEntity LIKE2 = new LikeEntity(
+    public static final LikeEntity STATIC_LIKE2 = new LikeEntity(
             2L,
-            MEMBER2,
-            PUBLIC_POST
+            STATIC_MEMBER2,
+            STATIC_PUBLIC_POST
     );
 }

--- a/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
+++ b/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
@@ -7,6 +7,7 @@ import com.apps.pochak.login.dto.response.OAuthMemberResponse;
 import com.apps.pochak.login.service.AppleOAuthService;
 import com.apps.pochak.login.service.GoogleOAuthService;
 import com.apps.pochak.login.service.OAuthService;
+import com.apps.pochak.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.MockMultipartFileConverter.getSampleMultipartFile;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(OAuthController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 public class OAuthControllerTest extends ControllerTest {
+    private static final Member MEMBER1 = STATIC_MEMBER1;
 
     @MockBean
     OAuthService oAuthService;

--- a/src/test/java/com/apps/pochak/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/apps/pochak/member/controller/MemberControllerTest.java
@@ -7,6 +7,7 @@ import com.apps.pochak.member.dto.response.MemberElements;
 import com.apps.pochak.member.dto.response.ProfileResponse;
 import com.apps.pochak.member.dto.response.ProfileUpdateResponse;
 import com.apps.pochak.member.service.MemberService;
+import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.post.dto.PostElements;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,9 +27,9 @@ import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.MockMultipartFileConverter.getSampleMultipartFile;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -47,6 +48,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(MemberController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class MemberControllerTest extends ControllerTest {
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Member MEMBER2 = STATIC_MEMBER2;
+    private static final Post PUBLIC_POST = STATIC_PUBLIC_POST;
 
     private static final List<Member> MEMBER_LIST = List.of(
             MEMBER1,

--- a/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
+++ b/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
@@ -7,9 +7,9 @@ public class MemberFixture {
 
     private static final String PROFILE_IMAGE = "https://avatars.githubusercontent.com/u/163827369?s=200&v=4";
 
-    public static final Member MEMBER1 = new Member(
+    public static final Member STATIC_MEMBER1 = new Member(
             1L,
-            "member1",
+            "static-member1",
             "1번 회원의 이름",
             "한 줄 소개",
             "aaa@pochak.com",
@@ -20,9 +20,9 @@ public class MemberFixture {
             "SOCIAL_REFRESH_TOKEN"
     );
 
-    public static final Member MEMBER2 = new Member(
+    public static final Member STATIC_MEMBER2 = new Member(
             2L,
-            "member2",
+            "static-member2",
             "2번 회원의 이름",
             "한 줄 소개",
             "aaa@pochak.com",
@@ -33,29 +33,51 @@ public class MemberFixture {
             "SOCIAL_REFRESH_TOKEN"
     );
 
-    public static final Member MEMBER3 = new Member(
-            3L,
-            "member3",
-            "3번 회원의 이름",
-            "한 줄 소개",
-            "aaa@pochak.com",
-            PROFILE_IMAGE,
-            "REFRESH_TOKEN",
-            "SOCIAL_ID",
-            SocialType.APPLE,
-            "SOCIAL_REFRESH_TOKEN"
-    );
+    public static final Member OWNER = Member.signupMember()
+            .name("게시물 업로드한 사람")
+            .email("aaa@pochak.com")
+            .handle("owner")
+            .message("한 줄 소개")
+            .socialId("SOCIAL_ID")
+            .profileImage(PROFILE_IMAGE)
+            .refreshToken("REFRESH_TOKEN")
+            .socialType(SocialType.GOOGLE)
+            .socialRefreshToken("SOCIAL_REFRESH_TOKEN")
+            .build();
 
-    public static final Member BLOCKED_MEMBER = new Member(
-            4L,
-            "blocked_member",
-            "차단된 회원의 이름",
-            "한 줄 소개",
-            "aaa@pochak.com",
-            PROFILE_IMAGE,
-            "REFRESH_TOKEN",
-            "SOCIAL_ID",
-            SocialType.APPLE,
-            "SOCIAL_REFRESH_TOKEN"
-    );
+    public static final Member TAGGED_MEMBER1 = Member.signupMember()
+            .name("태그된 사람 1번")
+            .email("aaa@pochak.com")
+            .handle("tagged_member1")
+            .message("한 줄 소개")
+            .socialId("SOCIAL_ID")
+            .profileImage(PROFILE_IMAGE)
+            .refreshToken("REFRESH_TOKEN")
+            .socialType(SocialType.GOOGLE)
+            .socialRefreshToken("SOCIAL_REFRESH_TOKEN")
+            .build();
+
+    public static final Member TAGGED_MEMBER2 = Member.signupMember()
+            .name("태그된 사람 2번")
+            .email("aaa@pochak.com")
+            .handle("tagged_member1")
+            .message("한 줄 소개")
+            .socialId("SOCIAL_ID")
+            .profileImage(PROFILE_IMAGE)
+            .refreshToken("REFRESH_TOKEN")
+            .socialType(SocialType.GOOGLE)
+            .socialRefreshToken("SOCIAL_REFRESH_TOKEN")
+            .build();
+
+    public static final Member LOGIN_MEMBER = Member.signupMember()
+            .name("로그인한 사람")
+            .email("aaa@pochak.com")
+            .handle("login_member")
+            .message("한 줄 소개")
+            .socialId("SOCIAL_ID")
+            .profileImage(PROFILE_IMAGE)
+            .refreshToken("REFRESH_TOKEN")
+            .socialType(SocialType.GOOGLE)
+            .socialRefreshToken("SOCIAL_REFRESH_TOKEN")
+            .build();
 }

--- a/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
+++ b/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
@@ -60,7 +60,7 @@ public class MemberFixture {
     public static final Member TAGGED_MEMBER2 = Member.signupMember()
             .name("태그된 사람 2번")
             .email("aaa@pochak.com")
-            .handle("tagged_member1")
+            .handle("tagged_member2")
             .message("한 줄 소개")
             .socialId("SOCIAL_ID")
             .profileImage(PROFILE_IMAGE)

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -1,10 +1,13 @@
 package com.apps.pochak.memories.controller;
 
 import com.apps.pochak.auth.domain.Accessor;
+import com.apps.pochak.follow.domain.Follow;
 import com.apps.pochak.global.ControllerTest;
+import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.memories.dto.response.MemoriesPostResponse;
 import com.apps.pochak.memories.dto.response.MemoriesPreviewResponse;
 import com.apps.pochak.memories.service.MemoriesService;
+import com.apps.pochak.tag.domain.Tag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,13 +19,13 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import java.util.List;
 
-import static com.apps.pochak.follow.fixture.FollowFixture.RECEIVE_FOLLOW;
-import static com.apps.pochak.follow.fixture.FollowFixture.SEND_FOLLOW;
+import static com.apps.pochak.follow.fixture.FollowFixture.STATIC_RECEIVE_FOLLOW;
+import static com.apps.pochak.follow.fixture.FollowFixture.STATIC_SEND_FOLLOW;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
 import static com.apps.pochak.tag.fixture.TagFixture.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -41,6 +44,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(MemoriesController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class MemoriesControllerTest extends ControllerTest {
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Member MEMBER2 = STATIC_MEMBER2;
+    private static final Follow SEND_FOLLOW = STATIC_SEND_FOLLOW;
+    private static final Follow RECEIVE_FOLLOW = STATIC_RECEIVE_FOLLOW;
+    private static final Tag APPROVED_TAG = STATIC_APPROVED_TAG;
 
     @MockBean
     MemoriesService memoriesService;

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -26,7 +26,7 @@ import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
 import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
 import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
-import static com.apps.pochak.tag.fixture.TagFixture.*;
+import static com.apps.pochak.tag.fixture.TagFixture.STATIC_APPROVED_TAG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -78,8 +78,8 @@ class MemoriesControllerTest extends ControllerTest {
                         .countTagged(30L)
                         .firstTagged(APPROVED_TAG)
                         .firstTag(APPROVED_TAG)
-                        .firstTaggedWith(TAG1_WITH_ONE_POST)
-                        .latestTag(TAG2_WITH_ONE_POST)
+                        .firstTaggedWith(APPROVED_TAG)
+                        .latestTag(APPROVED_TAG)
                         .build()
                 );
 

--- a/src/test/java/com/apps/pochak/post/controller/PostControllerTest.java
+++ b/src/test/java/com/apps/pochak/post/controller/PostControllerTest.java
@@ -1,10 +1,14 @@
 package com.apps.pochak.post.controller;
 
 import com.apps.pochak.auth.domain.Accessor;
+import com.apps.pochak.comment.domain.Comment;
 import com.apps.pochak.global.ControllerTest;
+import com.apps.pochak.member.domain.Member;
+import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.post.dto.PostElements;
 import com.apps.pochak.post.dto.response.PostDetailResponse;
 import com.apps.pochak.post.service.PostService;
+import com.apps.pochak.tag.domain.Tag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,14 +20,14 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import java.util.List;
 
-import static com.apps.pochak.comment.fixture.CommentFixture.CHILD_COMMENT;
+import static com.apps.pochak.comment.fixture.CommentFixture.STATIC_CHILD_COMMENT;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.MockMultipartFileConverter.getSampleMultipartFile;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
-import static com.apps.pochak.tag.fixture.TagFixture.APPROVED_TAG;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
+import static com.apps.pochak.tag.fixture.TagFixture.STATIC_APPROVED_TAG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -43,6 +47,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(PostController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class PostControllerTest extends ControllerTest {
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Comment CHILD_COMMENT = STATIC_CHILD_COMMENT;
+    private static final Post PUBLIC_POST = STATIC_PUBLIC_POST;
+    private static final Tag APPROVED_TAG = STATIC_APPROVED_TAG;
 
     @MockBean
     PostService postService;

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -2,9 +2,18 @@ package com.apps.pochak.post.domain.repository;
 
 import com.apps.pochak.global.TestQuerydslConfig;
 import com.apps.pochak.member.domain.repository.MemberRepository;
+import com.apps.pochak.tag.domain.repository.TagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+
+import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
+import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.tag.fixture.TagFixture.APPROVED_TAG;
 
 @DataJpaTest
 @Import(TestQuerydslConfig.class)
@@ -13,7 +22,81 @@ class PostCustomRepositoryTest {
     PostCustomRepository postCustomRepository;
 
     @Autowired
+    PostRepository postRepository;
+
+    @Autowired
     MemberRepository memberRepository;
 
-    
+    @Autowired
+    TagRepository tagRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.save(MEMBER1);
+        memberRepository.save(MEMBER2);
+
+        PUBLIC_POST.makePublic();
+        postRepository.save(PUBLIC_POST);
+        tagRepository.save(APPROVED_TAG);
+    }
+
+    @DisplayName("차단된 게시물을 제외한 게시물이 조회된다.")
+    @Test
+    void findById() throws Exception{
+        //given
+        
+        //when
+        
+        //then
+    }
+
+    @DisplayName("유효한 id가 없는 경우 조회되지 않는다.")
+    @Test
+    void findById_WhenIdIsInvalid() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("게시물을 업로드한 사람이 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
+    @Test
+    void findById_WhenOwnerBlockLoginMember() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("게시물에 태그된 사람 중 한명이라도 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
+    @Test
+    void findById_WhenTaggedMemberBlockLoginMember() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("현재 로그인한 사람이 게시물을 업로드한 사람을 차단하였다면 조회되지 않는다.")
+    @Test
+    void findById_WhenLoginMemberBlockOwner() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("현재 로그인한 사람이 게시물에 태그된 사람 중 한명이라도 차단하였다면 조회되지 않는다.")
+    @Test
+    void findPostByIdWithoutBlockPostWhenLoginMemberBlockTaggedMember() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
 }

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -1,0 +1,17 @@
+package com.apps.pochak.post.domain.repository;
+
+import com.apps.pochak.global.TestQueryDSLConfig;
+import com.apps.pochak.member.domain.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestQueryDSLConfig.class)
+class PostCustomRepositoryTest {
+    @Autowired
+    PostCustomRepository postCustomRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+}

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -1,23 +1,42 @@
 package com.apps.pochak.post.domain.repository;
 
+import com.apps.pochak.block.domain.Block;
+import com.apps.pochak.block.domain.repository.BlockRepository;
 import com.apps.pochak.global.TestQuerydslConfig;
+import com.apps.pochak.global.api_payload.exception.GeneralException;
+import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
+import com.apps.pochak.member.fixture.MemberFixture;
+import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.domain.repository.TagRepository;
-import org.junit.jupiter.api.BeforeEach;
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
-import static com.apps.pochak.tag.fixture.TagFixture.APPROVED_TAG;
+import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
+import static com.apps.pochak.post.fixture.PostFixture.POST_WITH_MULTI_TAG;
+import static com.apps.pochak.tag.fixture.TagFixture.TAG1_WITH_ONE_POST;
+import static com.apps.pochak.tag.fixture.TagFixture.TAG2_WITH_ONE_POST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
 @Import(TestQuerydslConfig.class)
 class PostCustomRepositoryTest {
+
+    private static final Post POST = POST_WITH_MULTI_TAG;
+    private static final Tag TAG1 = TAG1_WITH_ONE_POST;
+    private static final Tag TAG2 = TAG2_WITH_ONE_POST;
+    private static final Member OWNER = MemberFixture.OWNER;
+    private static final Member TAGGED_MEMBER1 = MemberFixture.TAGGED_MEMBER1;
+    private static final Member TAGGED_MEMBER2 = MemberFixture.TAGGED_MEMBER2;
+    private static final Member LOGIN_MEMBER = MemberFixture.LOGIN_MEMBER;
+
     @Autowired
     PostCustomRepository postCustomRepository;
 
@@ -30,73 +49,177 @@ class PostCustomRepositoryTest {
     @Autowired
     TagRepository tagRepository;
 
-    @BeforeEach
-    void setUp() {
-        memberRepository.save(MEMBER1);
-        memberRepository.save(MEMBER2);
+    @Autowired
+    BlockRepository blockRepository;
 
-        PUBLIC_POST.makePublic();
-        postRepository.save(PUBLIC_POST);
-        tagRepository.save(APPROVED_TAG);
+    private SavedPostData savePost() {
+        return SavedPostData.of()
+                .owner(memberRepository.save(OWNER))
+                .taggedMember1(memberRepository.save(TAGGED_MEMBER1))
+                .taggedMember2(memberRepository.save(TAGGED_MEMBER2))
+                .loginMember(memberRepository.save(LOGIN_MEMBER))
+                .savedPost(postRepository.save(POST))
+                .tag1(tagRepository.save(TAG1))
+                .tag2(tagRepository.save(TAG2))
+                .build();
     }
 
     @DisplayName("차단된 게시물을 제외한 게시물이 조회된다.")
     @Test
-    void findById() throws Exception{
+    void findById() throws Exception {
         //given
-        
+        SavedPostData savedPostData = savePost();
+        Member loginMember = savedPostData.getLoginMember();
+        Post savedPost = savedPostData.getSavedPost();
+
         //when
-        
+        Post findPost = postCustomRepository.findPostByIdWithoutBlockPost(savedPost.getId(), loginMember.getId());
+
         //then
+        assertEquals(savedPost.getId(), findPost.getId());
     }
 
     @DisplayName("유효한 id가 없는 경우 조회되지 않는다.")
     @Test
-    void findById_WhenIdIsInvalid() throws Exception{
+    void findById_WhenIdIsInvalid() throws Exception {
         //given
+        SavedPostData savedPostData = savePost();
+        Member loginMember = savedPostData.getLoginMember();
+        Long invalidPostId = 0L;
 
         //when
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> postCustomRepository.findPostByIdWithoutBlockPost(invalidPostId, loginMember.getId())
+        );
 
         //then
+        assertEquals(BLOCKED_POST, exception.getCode());
     }
 
     @DisplayName("게시물을 업로드한 사람이 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
     @Test
-    void findById_WhenOwnerBlockLoginMember() throws Exception{
+    void findById_WhenOwnerBlockLoginMember() throws Exception {
         //given
+        SavedPostData savedPostData = savePost();
+        Member owner = savedPostData.getOwner();
+        Member loginMember = savedPostData.getLoginMember();
+        Post savedPost = savedPostData.getSavedPost();
+
+        blockRepository.save(new Block(
+                owner,
+                loginMember
+        ));
 
         //when
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> postCustomRepository.findPostByIdWithoutBlockPost(savedPost.getId(), loginMember.getId())
+        );
 
         //then
+        assertEquals(BLOCKED_POST, exception.getCode());
     }
 
     @DisplayName("게시물에 태그된 사람 중 한명이라도 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
     @Test
-    void findById_WhenTaggedMemberBlockLoginMember() throws Exception{
+    void findById_WhenTaggedMemberBlockLoginMember() throws Exception {
         //given
+        SavedPostData savedPostData = savePost();
+        Member taggedMember1 = savedPostData.getTaggedMember1();
+        Member loginMember = savedPostData.getLoginMember();
+        Post savedPost = savedPostData.getSavedPost();
+
+        blockRepository.save(new Block(
+                taggedMember1,
+                loginMember
+        ));
 
         //when
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> postCustomRepository.findPostByIdWithoutBlockPost(savedPost.getId(), loginMember.getId())
+        );
 
         //then
+        assertEquals(BLOCKED_POST, exception.getCode());
     }
 
     @DisplayName("현재 로그인한 사람이 게시물을 업로드한 사람을 차단하였다면 조회되지 않는다.")
     @Test
-    void findById_WhenLoginMemberBlockOwner() throws Exception{
+    void findById_WhenLoginMemberBlockOwner() throws Exception {
         //given
+        SavedPostData savedPostData = savePost();
+        Member loginMember = savedPostData.getLoginMember();
+        Member owner = savedPostData.getOwner();
+        Post savedPost = savedPostData.getSavedPost();
+
+        blockRepository.save(new Block(
+                loginMember,
+                owner
+        ));
 
         //when
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> postCustomRepository.findPostByIdWithoutBlockPost(savedPost.getId(), loginMember.getId())
+        );
 
         //then
+        assertEquals(BLOCKED_POST, exception.getCode());
     }
 
     @DisplayName("현재 로그인한 사람이 게시물에 태그된 사람 중 한명이라도 차단하였다면 조회되지 않는다.")
     @Test
-    void findPostByIdWithoutBlockPostWhenLoginMemberBlockTaggedMember() throws Exception{
+    void findPostByIdWithoutBlockPostWhenLoginMemberBlockTaggedMember() throws Exception {
         //given
+        SavedPostData savedPostData = savePost();
+        Member loginMember = savedPostData.getLoginMember();
+        Member taggedMember1 = savedPostData.getTaggedMember1();
+        Post savedPost = savedPostData.getSavedPost();
+
+        blockRepository.save(new Block(
+                loginMember,
+                taggedMember1
+        ));
 
         //when
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> postCustomRepository.findPostByIdWithoutBlockPost(savedPost.getId(), loginMember.getId())
+        );
 
         //then
+        assertEquals(BLOCKED_POST, exception.getCode());
+    }
+}
+
+@Data
+class SavedPostData {
+    private Post savedPost;
+    private Tag tag1;
+    private Tag tag2;
+    private Member owner;
+    private Member taggedMember1;
+    private Member taggedMember2;
+    private Member loginMember;
+
+    @Builder(builderMethodName = "of")
+    public SavedPostData(
+            final Post savedPost,
+            final Tag tag1,
+            final Tag tag2,
+            final Member owner,
+            final Member taggedMember1,
+            final Member taggedMember2,
+            final Member loginMember
+    ) {
+        this.savedPost = savedPost;
+        this.tag1 = tag1;
+        this.tag2 = tag2;
+        this.owner = owner;
+        this.taggedMember1 = taggedMember1;
+        this.taggedMember2 = taggedMember2;
+        this.loginMember = loginMember;
     }
 }

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -1,17 +1,19 @@
 package com.apps.pochak.post.domain.repository;
 
-import com.apps.pochak.global.TestQueryDSLConfig;
+import com.apps.pochak.global.TestQuerydslConfig;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(TestQueryDSLConfig.class)
+@Import(TestQuerydslConfig.class)
 class PostCustomRepositoryTest {
     @Autowired
     PostCustomRepository postCustomRepository;
 
     @Autowired
     MemberRepository memberRepository;
+
+    
 }

--- a/src/test/java/com/apps/pochak/post/fixture/PostFixture.java
+++ b/src/test/java/com/apps/pochak/post/fixture/PostFixture.java
@@ -12,30 +12,33 @@ public class PostFixture {
 
     private static final String POST_IMAGE = "https://avatars.githubusercontent.com/u/163827369?s=200&v=4";
 
-    public static final Post PUBLIC_POST = new Post(
+    public static final Post STATIC_PUBLIC_POST = new Post(
             1L,
             PUBLIC,
             LocalDateTime.now(),
-            MEMBER1,
+            STATIC_MEMBER1,
             POST_IMAGE,
             "공개 게시물 캡션입니다."
     );
 
-    public static final Post PRIVATE_POST = new Post(
+    public static final Post STATIC_PRIVATE_POST = new Post(
             2L,
             PRIVATE,
             LocalDateTime.now(),
-            MEMBER2,
+            STATIC_MEMBER2,
             POST_IMAGE,
             "아직 수락되지 않은 게시물의 캡션입니다."
     );
 
-    public static final Post POST_WITH_MULTI_TAG = new Post(
-            3L,
-            PUBLIC,
-            LocalDateTime.now(),
-            MEMBER3,
-            POST_IMAGE,
-            "공개 게시물2 캡션입니다."
-    ); // 다수의 태그 생성 목적
+    public static final Post PUBLIC_POST = Post.builder()
+            .owner(OWNER)
+            .postImage(POST_IMAGE)
+            .caption("하나의 태그를 가진 게시물입니다.")
+            .build();
+
+    public static final Post POST_WITH_MULTI_TAG = Post.builder()
+            .owner(OWNER)
+            .postImage(POST_IMAGE)
+            .caption("다중 태그를 가진 게시물입니다.")
+            .build();
 }

--- a/src/test/java/com/apps/pochak/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/apps/pochak/report/controller/ReportControllerTest.java
@@ -2,6 +2,8 @@ package com.apps.pochak.report.controller;
 
 import com.apps.pochak.auth.domain.Accessor;
 import com.apps.pochak.global.ControllerTest;
+import com.apps.pochak.member.domain.Member;
+import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.report.domain.ReportType;
 import com.apps.pochak.report.dto.request.ReportUploadRequest;
 import com.apps.pochak.report.service.ReportService;
@@ -18,8 +20,8 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.post.fixture.PostFixture.PUBLIC_POST;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -35,6 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ReportController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class ReportControllerTest extends ControllerTest {
+    private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Post PUBLIC_POST = STATIC_PUBLIC_POST;
 
     @MockBean
     ReportService reportService;

--- a/src/test/java/com/apps/pochak/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/apps/pochak/tag/controller/TagControllerTest.java
@@ -2,6 +2,8 @@ package com.apps.pochak.tag.controller;
 
 import com.apps.pochak.auth.domain.Accessor;
 import com.apps.pochak.global.ControllerTest;
+import com.apps.pochak.member.domain.Member;
+import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.service.TagService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,8 +17,8 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.api_payload.code.status.SuccessStatus.SUCCESS_ACCEPT;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.tag.fixture.TagFixture.WAITING_TAG;
+import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.tag.fixture.TagFixture.STATIC_WAITING_TAG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -35,6 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(TagController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class TagControllerTest extends ControllerTest {
+    private static final Member MEMBER = STATIC_MEMBER1;
+    private static final Tag WAITING_TAG = STATIC_WAITING_TAG;
 
     @MockBean
     TagService tagService;
@@ -42,9 +46,9 @@ class TagControllerTest extends ControllerTest {
     @BeforeEach
     void setUp() {
         given(jwtProvider.validateAccessToken(any())).willReturn(true);
-        given(jwtProvider.getSubject(any())).willReturn(MEMBER1.getId().toString());
+        given(jwtProvider.getSubject(any())).willReturn(MEMBER.getId().toString());
         given(loginArgumentResolver.resolveArgument(any(), any(), any(), any()))
-                .willReturn(Accessor.member(MEMBER1.getId()));
+                .willReturn(Accessor.member(MEMBER.getId()));
     }
 
     @Test

--- a/src/test/java/com/apps/pochak/tag/fixture/TagFixture.java
+++ b/src/test/java/com/apps/pochak/tag/fixture/TagFixture.java
@@ -2,33 +2,36 @@ package com.apps.pochak.tag.fixture;
 
 import com.apps.pochak.tag.domain.Tag;
 
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.MEMBER2;
+import static com.apps.pochak.member.fixture.MemberFixture.*;
 import static com.apps.pochak.post.fixture.PostFixture.*;
 
 public class TagFixture {
-    public static final Tag APPROVED_TAG = new Tag(
+    public static final Tag STATIC_APPROVED_TAG = new Tag(
             1L,
-            PUBLIC_POST,
-            MEMBER2,
+            STATIC_PUBLIC_POST,
+            STATIC_MEMBER2,
             true
     );
-    public static final Tag WAITING_TAG = new Tag(
+
+    public static final Tag STATIC_WAITING_TAG = new Tag(
             2L,
-            PRIVATE_POST,
-            MEMBER1,
+            STATIC_PRIVATE_POST,
+            STATIC_MEMBER1,
             false
     );
-    public static final Tag TAG1_WITH_ONE_POST = new Tag(
-            3L,
-            POST_WITH_MULTI_TAG,
-            MEMBER1,
-            true
-    );
-    public static final Tag TAG2_WITH_ONE_POST = new Tag(
-            4L,
-            POST_WITH_MULTI_TAG,
-            MEMBER2,
-            true
-    );
+
+    public static final Tag APPROVAL_TAG = Tag.builder()
+            .post(PUBLIC_POST)
+            .member(TAGGED_MEMBER1)
+            .build();
+
+    public static final Tag TAG1_WITH_ONE_POST = Tag.builder()
+            .post(POST_WITH_MULTI_TAG)
+            .member(TAGGED_MEMBER1)
+            .build();
+
+    public static final Tag TAG2_WITH_ONE_POST = Tag.builder()
+            .post(POST_WITH_MULTI_TAG)
+            .member(TAGGED_MEMBER2)
+            .build();
 }


### PR DESCRIPTION
## 📒 개요

기존의 PostRepository에서 JPQL로 작성한 코드를 QueryDSL을 사용하여 리팩토링함으로써 재사용과 가독성을 높여보자...~
> 생각보다 querydsl 문법은 구글링하면서 써보니까 어렵진 않았는데,
> 차단 쿼리를 아예 바꿔서 생각하는 보는게 어려웠어요

## 📍 Issue 번호

- #67

## 🛠️ 작업사항

- [x] 기존에 in(서브쿼리) 성능 지옥을 left join을 사용한 방식으로 변경하였습니다!! 😱
- [x] test 코드 작성해야 함

## 🧰 추가 논의사항

- **작업 상황 공유를 위해 미리 PR을 날린것 뿐.. 아직 approve하지 말아주세요!**
- 일단 쿼리 하나만 바꿨는데 로직 맞는 것 같은지 확인해주십쇼
- 제 생각엔 이거 메소드 하나 고칠때마다 PR 하나씩 날려야될 것 같아요ㅋㅋㅋㅋㅋ 생각보다 메소드 하나 고친 뒤에 고쳐야할 곳이 많네요
- 그리고 은근 고민되는데 `PostCustomRepository`가 나을까요 `CustomPostRepository`가 나을까요?