### PR TITLE
[refactor/#67-find-by-id] `findByIdWithoutBlockPost()` V2 리팩토링

### DIFF
--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -1,6 +1,5 @@
 package com.apps.pochak.post.domain.repository;
 
-import com.apps.pochak.global.BaseEntityStatus;
 import com.apps.pochak.global.api_payload.exception.GeneralException;
 import com.apps.pochak.post.domain.Post;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 import static com.apps.pochak.block.domain.QBlock.block;
+import static com.apps.pochak.global.BaseEntityStatus.ACTIVE;
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
 import static com.apps.pochak.post.domain.PostStatus.PUBLIC;
 import static com.apps.pochak.post.domain.QPost.post;
@@ -40,9 +40,9 @@ public class PostCustomRepository {
                                 checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
                                         .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
                         )
+                        .where(post.status.eq(ACTIVE).and(post.postStatus.eq(PUBLIC)))
                         .groupBy(post)
                         .having(block.id.count().eq(0L))
-                        .where(post.status.eq(BaseEntityStatus.ACTIVE).and(post.postStatus.eq(PUBLIC)))
                         .fetchOne()
         );
     }

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -27,7 +27,7 @@ public class PostCustomRepository {
         return findByIdWithoutBlockPost(postId, loginMemberId).orElseThrow(() -> new GeneralException(BLOCKED_POST));
     }
 
-    public Optional<Post> findByIdWithoutBlockPost(
+    private Optional<Post> findByIdWithoutBlockPost(
             final Long postId,
             final Long loginMemberId
     ) {

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -34,17 +34,14 @@ public class PostCustomRepository {
         return Optional.ofNullable(
                 query.selectFrom(post)
                         .join(post.owner).fetchJoin()
-                        .join(tag).on(tag.post.eq(post))
+                        .join(tag).on(tag.post.eq(post).and(post.id.eq(postId)))
                         .leftJoin(block).on(
                                 checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
                                         .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
                         )
                         .groupBy(post)
                         .having(block.id.count().eq(0L))
-                        .where(
-                                post.id.eq(postId),
-                                post.status.eq(BaseEntityStatus.ACTIVE)
-                        )
+                        .where(post.status.eq(BaseEntityStatus.ACTIVE))
                         .fetchOne()
         );
     }

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static com.apps.pochak.block.domain.QBlock.block;
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
+import static com.apps.pochak.post.domain.PostStatus.PUBLIC;
 import static com.apps.pochak.post.domain.QPost.post;
 import static com.apps.pochak.tag.domain.QTag.tag;
 
@@ -41,7 +42,7 @@ public class PostCustomRepository {
                         )
                         .groupBy(post)
                         .having(block.id.count().eq(0L))
-                        .where(post.status.eq(BaseEntityStatus.ACTIVE))
+                        .where(post.status.eq(BaseEntityStatus.ACTIVE).and(post.postStatus.eq(PUBLIC)))
                         .fetchOne()
         );
     }

--- a/src/main/java/com/apps/pochak/post/service/PostService.java
+++ b/src/main/java/com/apps/pochak/post/service/PostService.java
@@ -70,9 +70,6 @@ public class PostService {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Post post = postCustomRepository.findPostByIdWithoutBlockPost(postId, accessor.getMemberId());
         final List<Tag> tagList = tagRepository.findTagsByPost(post);
-        if (post.isPrivate()) {
-            throw new GeneralException(PRIVATE_POST);
-        }
         final Boolean isFollow = post.isOwner(loginMember) ?
                 null : followRepository.existsBySenderAndReceiver(loginMember, post.getOwner());
         final Boolean isLike = likeRepository.existsByLikeMemberAndLikedPost(loginMember, post);

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -2,14 +2,12 @@ package com.apps.pochak.post.domain.repository;
 
 import com.apps.pochak.block.domain.Block;
 import com.apps.pochak.block.domain.repository.BlockRepository;
-import com.apps.pochak.global.BaseEntityStatus;
 import com.apps.pochak.global.TestQuerydslConfig;
 import com.apps.pochak.global.api_payload.exception.GeneralException;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.apps.pochak.member.fixture.MemberFixture;
 import com.apps.pochak.post.domain.Post;
-import com.apps.pochak.post.domain.PostStatus;
 import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.domain.repository.TagRepository;
 import lombok.Builder;
@@ -216,10 +214,7 @@ class SavedPostData {
             final Member taggedMember2,
             final Member loginMember
     ) {
-        savedPost.setStatus(BaseEntityStatus.ACTIVE);
         savedPost.makePublic();
-        tag1.setStatus(BaseEntityStatus.ACTIVE);
-        tag2.setStatus(BaseEntityStatus.ACTIVE);
         this.savedPost = savedPost;
         this.tag1 = tag1;
         this.tag2 = tag2;

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -64,7 +64,7 @@ class PostCustomRepositoryTest {
                 .build();
     }
 
-    @DisplayName("차단된 게시물을 제외한 게시물이 조회된다.")
+    @DisplayName("[findPostByIdWithoutBlockPost] 차단된 게시물을 제외한 게시물이 조회된다.")
     @Test
     void findById() throws Exception {
         //given
@@ -79,7 +79,7 @@ class PostCustomRepositoryTest {
         assertEquals(savedPost.getId(), findPost.getId());
     }
 
-    @DisplayName("유효한 id가 없는 경우 조회되지 않는다.")
+    @DisplayName("[findPostByIdWithoutBlockPost] 유효한 id가 없는 경우 조회되지 않는다.")
     @Test
     void findById_WhenIdIsInvalid() throws Exception {
         //given
@@ -97,7 +97,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("게시물을 업로드한 사람이 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
+    @DisplayName("[findPostByIdWithoutBlockPost] 게시물을 업로드한 사람이 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
     @Test
     void findById_WhenOwnerBlockLoginMember() throws Exception {
         //given
@@ -121,7 +121,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("게시물에 태그된 사람 중 한명이라도 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
+    @DisplayName("[findPostByIdWithoutBlockPost] 게시물에 태그된 사람 중 한명이라도 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
     @Test
     void findById_WhenTaggedMemberBlockLoginMember() throws Exception {
         //given
@@ -145,7 +145,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("현재 로그인한 사람이 게시물을 업로드한 사람을 차단하였다면 조회되지 않는다.")
+    @DisplayName("[findPostByIdWithoutBlockPost] 현재 로그인한 사람이 게시물을 업로드한 사람을 차단하였다면 조회되지 않는다.")
     @Test
     void findById_WhenLoginMemberBlockOwner() throws Exception {
         //given
@@ -169,9 +169,9 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("현재 로그인한 사람이 게시물에 태그된 사람 중 한명이라도 차단하였다면 조회되지 않는다.")
+    @DisplayName("[findPostByIdWithoutBlockPost] 현재 로그인한 사람이 게시물에 태그된 사람 중 한명이라도 차단하였다면 조회되지 않는다.")
     @Test
-    void findPostByIdWithoutBlockPostWhenLoginMemberBlockTaggedMember() throws Exception {
+    void findPostById_WhenLoginMemberBlockTaggedMember() throws Exception {
         //given
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -2,12 +2,14 @@ package com.apps.pochak.post.domain.repository;
 
 import com.apps.pochak.block.domain.Block;
 import com.apps.pochak.block.domain.repository.BlockRepository;
+import com.apps.pochak.global.BaseEntityStatus;
 import com.apps.pochak.global.TestQuerydslConfig;
 import com.apps.pochak.global.api_payload.exception.GeneralException;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.apps.pochak.member.fixture.MemberFixture;
 import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.post.domain.PostStatus;
 import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.domain.repository.TagRepository;
 import lombok.Builder;
@@ -64,7 +66,7 @@ class PostCustomRepositoryTest {
                 .build();
     }
 
-    @DisplayName("[findPostByIdWithoutBlockPost] 차단된 게시물을 제외한 게시물이 조회된다.")
+    @DisplayName("[게시물 id 조회] 차단된 게시물을 제외한 게시물이 조회된다.")
     @Test
     void findById() throws Exception {
         //given
@@ -79,7 +81,7 @@ class PostCustomRepositoryTest {
         assertEquals(savedPost.getId(), findPost.getId());
     }
 
-    @DisplayName("[findPostByIdWithoutBlockPost] 유효한 id가 없는 경우 조회되지 않는다.")
+    @DisplayName("[게시물 id 조회] 유효한 id가 없는 경우 조회되지 않는다.")
     @Test
     void findById_WhenIdIsInvalid() throws Exception {
         //given
@@ -97,7 +99,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("[findPostByIdWithoutBlockPost] 게시물을 업로드한 사람이 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
+    @DisplayName("[게시물 id 조회] 업로더가 현재 유저를 차단하였다면 조회되지 않는다.")
     @Test
     void findById_WhenOwnerBlockLoginMember() throws Exception {
         //given
@@ -121,7 +123,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("[findPostByIdWithoutBlockPost] 게시물에 태그된 사람 중 한명이라도 현재 로그인한 사람을 차단하였다면 조회되지 않는다.")
+    @DisplayName("[게시물 id 조회] 태그된 사람이 현재 유저를 차단하였다면 조회되지 않는다.")
     @Test
     void findById_WhenTaggedMemberBlockLoginMember() throws Exception {
         //given
@@ -145,7 +147,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("[findPostByIdWithoutBlockPost] 현재 로그인한 사람이 게시물을 업로드한 사람을 차단하였다면 조회되지 않는다.")
+    @DisplayName("[게시물 id 조회] 현재 유저가 게시물 업로더를 차단하였다면 조회되지 않는다.")
     @Test
     void findById_WhenLoginMemberBlockOwner() throws Exception {
         //given
@@ -169,7 +171,7 @@ class PostCustomRepositoryTest {
         assertEquals(BLOCKED_POST, exception.getCode());
     }
 
-    @DisplayName("[findPostByIdWithoutBlockPost] 현재 로그인한 사람이 게시물에 태그된 사람 중 한명이라도 차단하였다면 조회되지 않는다.")
+    @DisplayName("[게시물 id 조회] 현재 유저가 게시물 업로더 중 한명이라도 차단하였다면 조회되지 않는다.")
     @Test
     void findPostById_WhenLoginMemberBlockTaggedMember() throws Exception {
         //given
@@ -214,6 +216,10 @@ class SavedPostData {
             final Member taggedMember2,
             final Member loginMember
     ) {
+        savedPost.setStatus(BaseEntityStatus.ACTIVE);
+        savedPost.makePublic();
+        tag1.setStatus(BaseEntityStatus.ACTIVE);
+        tag2.setStatus(BaseEntityStatus.ACTIVE);
         this.savedPost = savedPost;
         this.tag1 = tag1;
         this.tag2 = tag2;


### PR DESCRIPTION
## 📒 개요

findByIdWithoutBlockPost() 메소드 성능 측정하다가 부족한 점이 보여서 다시 리팩토링했습니다
- 사유: [V2 리팩토링 결과](https://smwu-pochak.github.io/posts/block-querydsl/#v2-%EB%A6%AC%ED%8C%A9%ED%86%A0%EB%A7%81-%EA%B2%B0%EA%B3%BC)

## 📍 Issue 번호

- #67 

## 🛠️ 작업사항

- [x] 조건절 on으로 이동
