### PR TITLE
[refactor/#80-postrepo-find-upload-post] `findUploadPost()` 리팩토링

### DIFF
--- a/src/main/java/com/apps/pochak/member/service/MemberService.java
+++ b/src/main/java/com/apps/pochak/member/service/MemberService.java
@@ -100,7 +100,7 @@ public class MemberService {
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Member owner = memberRepository.findByHandle(handle, loginMember);
-        final Page<Post> taggedPost = postCustomRepository.findUploadPostPage(owner.getId(), loginMember.getId(), pageable);
+        final Page<Post> taggedPost = postCustomRepository.findUploadPostPage(owner, loginMember, pageable);
         return PostElements.from(taggedPost);
     }
 

--- a/src/main/java/com/apps/pochak/member/service/MemberService.java
+++ b/src/main/java/com/apps/pochak/member/service/MemberService.java
@@ -100,7 +100,7 @@ public class MemberService {
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Member owner = memberRepository.findByHandle(handle, loginMember);
-        final Page<Post> taggedPost = postCustomRepository.findUploadPostPage(owner, loginMember, pageable);
+        final Page<Post> taggedPost = postCustomRepository.findUploadPostPage(owner, accessor.getMemberId(), pageable);
         return PostElements.from(taggedPost);
     }
 

--- a/src/main/java/com/apps/pochak/member/service/MemberService.java
+++ b/src/main/java/com/apps/pochak/member/service/MemberService.java
@@ -11,6 +11,7 @@ import com.apps.pochak.member.dto.response.MemberElements;
 import com.apps.pochak.member.dto.response.ProfileResponse;
 import com.apps.pochak.member.dto.response.ProfileUpdateResponse;
 import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.post.domain.repository.PostCustomRepository;
 import com.apps.pochak.post.domain.repository.PostRepository;
 import com.apps.pochak.post.dto.PostElements;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final PostRepository postRepository;
+    private final PostCustomRepository postCustomRepository;
     private final S3Service awsS3Service;
 
     @Transactional(readOnly = true)
@@ -98,7 +100,7 @@ public class MemberService {
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Member owner = memberRepository.findByHandle(handle, loginMember);
-        final Page<Post> taggedPost = postRepository.findUploadPost(owner, loginMember, pageable);
+        final Page<Post> taggedPost = postCustomRepository.findUploadPostPage(owner.getId(), loginMember.getId(), pageable);
         return PostElements.from(taggedPost);
     }
 

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -69,13 +69,13 @@ public class PostCustomRepository {
 
     private JPAQuery<Post> findUploadPost(
             final Member owner,
-            final Member loginMember
+            final Long loginMemberId
     ) {
         return query.selectFrom(post)
                 .join(tag).on(tag.post.eq(post))
                 .leftJoin(block).on(
-                        (checkTaggedMemberBlockLoginMember(loginMember))
-                                .or(checkLoginMemberBlockTaggedMember(loginMember))
+                        (checkTaggedMemberBlockLoginMember(loginMemberId))
+                                .or(checkLoginMemberBlockTaggedMember(loginMemberId))
                 )
                 .where(
                         post.owner.eq(owner),
@@ -89,28 +89,28 @@ public class PostCustomRepository {
 
     public Page<Post> findUploadPostPage(
             final Member owner,
-            final Member loginMember,
+            final Long loginMemberId,
             final Pageable pageable
     ) {
-        List<Post> contentPage = findUploadPost(owner, loginMember)
+        List<Post> contentPage = findUploadPost(owner, loginMemberId)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Long> countQuery = query.select(post.count())
                 .from(post)
-                .where(post.in(findUploadPost(owner, loginMember)));
+                .where(post.in(findUploadPost(owner, loginMemberId)));
 
         return PageableExecutionUtils.getPage(contentPage, pageable, countQuery::fetchOne);
     }
 
-    private BooleanExpression checkTaggedMemberBlockLoginMember(final Member loginMember) {
+    private BooleanExpression checkTaggedMemberBlockLoginMember(final Long loginMemberId) {
         return (block.blocker.eq(tag.member))
-                .and(block.blockedMember.eq(loginMember));
+                .and(block.blockedMember.id.eq(loginMemberId));
     }
 
-    private BooleanExpression checkLoginMemberBlockTaggedMember(final Member loginMember) {
-        return (block.blocker.eq(loginMember))
+    private BooleanExpression checkLoginMemberBlockTaggedMember(final Long loginMemberId) {
+        return (block.blocker.id.eq(loginMemberId))
                 .and(block.blockedMember.eq(tag.member));
     }
 }

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -3,12 +3,19 @@ package com.apps.pochak.post.domain.repository;
 import com.apps.pochak.global.BaseEntityStatus;
 import com.apps.pochak.global.api_payload.exception.GeneralException;
 import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.post.domain.PostStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.function.LongSupplier;
 
 import static com.apps.pochak.block.domain.QBlock.block;
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
@@ -57,5 +64,91 @@ public class PostCustomRepository {
     private BooleanExpression checkLoginMemberBlockOwnerOrTaggedMember(final Long loginMemberId) {
         return (block.blocker.id.eq(loginMemberId))
                 .and(block.blockedMember.eq(tag.member).or(block.blockedMember.eq(post.owner)));
+    }
+
+    public List<Post> findUploadPost(
+            final Long ownerId,
+            final Long loginMemberId
+    ) {
+        return query.selectFrom(post)
+                .join(tag).on(tag.post.eq(post))
+                .leftJoin(block).on(
+                        (checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId))
+                                .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
+                )
+                .groupBy(post)
+                .having(block.id.count().eq(0L))
+                .where(
+                        post.owner.id.eq(ownerId),
+                        post.status.eq(BaseEntityStatus.ACTIVE),
+                        post.postStatus.eq(PostStatus.PUBLIC)
+                )
+                .orderBy(post.allowedDate.desc())
+                .fetch();
+    }
+
+    public Page<Post> findUploadPostPage(
+            final Long ownerId,
+            final Long loginMemberId,
+            final Pageable pageable
+    ) {
+//        List<Post> contentPage = query.selectFrom(post)
+//                .join(tag).on(tag.post.eq(post))
+//                .leftJoin(block).on(
+//                        (checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId))
+//                                .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
+//                )
+//                .groupBy(post)
+//                .having(block.id.count().eq(0L))
+//                .where(
+//                        post.owner.id.eq(ownerId),
+//                        post.status.eq(BaseEntityStatus.ACTIVE),
+//                        post.postStatus.eq(PostStatus.PUBLIC)
+//                )
+//                .orderBy(post.allowedDate.desc())
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .fetch();
+//
+//        JPAQuery<Long> countQuery = query.select(post.count())
+//                .from(post)
+//                .join(tag).on(tag.post.eq(post))
+//                .leftJoin(block).on(
+//                        checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
+//                                .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
+//                )
+//                .groupBy(post)
+//                .having(block.id.count().eq(0L))
+//                .where(
+//                        post.owner.id.eq(ownerId),
+//                        post.status.eq(BaseEntityStatus.ACTIVE),
+//                        post.postStatus.eq(PostStatus.PUBLIC)
+//                );
+
+        JPAQuery<Post> content = query.selectFrom(post)
+                .join(tag).on(tag.post.eq(post))
+                .leftJoin(block).on(
+                        checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
+                                .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
+                )
+                .groupBy(post)
+                .having(block.id.count().eq(0L))
+                .where(
+                        post.owner.id.eq(ownerId),
+                        post.status.eq(BaseEntityStatus.ACTIVE),
+                        post.postStatus.eq(PostStatus.PUBLIC)
+                )
+                .orderBy(post.allowedDate.desc());
+
+//        JPAQuery<Long> countQuery = content.select(post.count());
+//        LongSupplier count = countQuery::fetchOne;
+        LongSupplier count = () -> content.fetch().size();
+
+        List<Post> contentPage = content
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return PageableExecutionUtils.getPage(contentPage, pageable, count);
     }
 }

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -214,7 +214,7 @@ class PostCustomRepositoryTest {
         savedPostData.getSavedPost().setStatus(BaseEntityStatus.ACTIVE);
 
         //when
-        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember, PageRequest.of(0, 1));
+        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember.getId(), PageRequest.of(0, 1));
 
         //then
         assertThat(posts.getTotalElements()).isEqualTo(1L);
@@ -238,7 +238,7 @@ class PostCustomRepositoryTest {
         ));
 
         //when
-        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember, PageRequest.of(0, 1));
+        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember.getId(), PageRequest.of(0, 1));
         //then
         assertThat(posts.getTotalElements()).isEqualTo(0L);
         assertFalse((posts).hasContent());
@@ -261,7 +261,7 @@ class PostCustomRepositoryTest {
         ));
 
         //when
-        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember, PageRequest.of(0, 1));
+        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember.getId(), PageRequest.of(0, 1));
         //then
         assertThat(posts.getTotalElements()).isEqualTo(0L);
         assertFalse((posts).hasContent());

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -204,7 +204,7 @@ class PostCustomRepositoryTest {
     }
 
     @Test
-    @DisplayName("현재 로그인한 사람이 특정 포차커가 업로드한 게시물을 페이지별로 조회한다.")
+    @DisplayName("[프로필 포착 게시물 조회] 현재 로그인한 사람이 특정 포차커가 업로드한 게시물을 페이지별로 조회한다.")
     void findUploadPostPage() {
         //given
         SavedPostData savedPostData = savePost();
@@ -222,7 +222,7 @@ class PostCustomRepositoryTest {
     }
 
     @Test
-    @DisplayName("현재 로그인한 사람이 게시물 작성자가 태그한 사람 중 한 명이라도 차단했을시 그 게시물은 조회되지 않는다.")
+    @DisplayName("[프로필 포착 게시물 조회] 현재 로그인한 사람이 게시물 작성자가 태그한 사람 중 한 명이라도 차단했을시 그 게시물은 조회되지 않는다.")
     void findUploadPostPageWithoutBlockPostWhenLoginMemberBlockTaggedMember() {
         //given
         SavedPostData savedPostData = savePost();
@@ -245,7 +245,7 @@ class PostCustomRepositoryTest {
     }
 
     @Test
-    @DisplayName("현재 로그인한 사람이 게시물 작성자가 태그한 사람 중 한 명에게라도 차단당했을시 그 게시물은 조회되지 않는다.")
+    @DisplayName("[프로필 포착 게시물 조회] 현재 로그인한 사람이 게시물 작성자가 태그한 사람 중 한 명에게라도 차단당했을시 그 게시물은 조회되지 않는다.")
     void findUploadPostPageWithoutBlockPostWhenTaggedMemberBlockLoginMember() {
         //given
         SavedPostData savedPostData = savePost();

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -213,7 +213,7 @@ class PostCustomRepositoryTest {
         savedPostData.getSavedPost().makePublic();
         savedPostData.getSavedPost().setStatus(BaseEntityStatus.ACTIVE);
         //when
-        List<Post> posts = postCustomRepository.findUploadPost(owner.getId(), loginMember.getId());
+        List<Post> posts = postCustomRepository.findUploadPost(owner.getId(), loginMember.getId()).fetch();
         //then
         assertThat(posts.size()).isEqualTo(1L);
         assertThat(posts.get(0)).isEqualTo(savedPostData.getSavedPost());


### PR DESCRIPTION
## 📒 개요

jpql과 페이징처리부분이 다릅니다

## 📍 Issue 번호

- #80 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] querydsl
- [x] 테스트
- [ ] 성능 개선

## 🧰 추가 논의사항

주석해놓은걸 추천받았으나, 테스트할 때 getTotalPage가 정확하게 나오지 않아서(왜 일까요) `fetch().size()`로 구현했습니다.
쿼리에서 `select(post.count())`를 쓰는 게 부하가 더 적을 것 같긴해서 더 고민해보겠습니다.. ㅠㅠ 
트러블슈팅 정리해놓은거...
https://www.notion.so/jpa-queryDSL-114c4903ef0d80bead8fcabf2ea14c98?pvs=4

```
JPAQuery<Long> countQuery = query.select(post.count())
                .from(post)
                .where(post.in(findUploadPost(ownerId, loginMemberId)));
                
// countQuery.fetchOne(): 1

// Hibernate: 
select count(p1_0.id) from post p1_0 where p1_0.id in (select p2_0.id from post p2_0 
join tag t1_0 on t1_0.post_id=p2_0.id 
left join block b1_0 on (b1_0.blocker_id=t1_0.member_id or b1_0.blocker_id=p2_0.owner_id) 
and b1_0.blocked_id=? or b1_0.blocker_id=? 
and (b1_0.blocked_id=t1_0.member_id or b1_0.blocked_id=p2_0.owner_id) 
where p2_0.owner_id=? 
and p2_0.status=? 
and p2_0.post_status=? 
group by p2_0.id 
having count(b1_0.id)=? 
order by p2_0.allowed_date desc)

JPAQuery<Long> countQuery = findUploadPost(ownerId, loginMemberId).select(post.count());

// countQuery.fetchOne(): 2
// Hibernate: 
select count(p1_0.id) from post p1_0 join tag t1_0 on t1_0.post_id=p1_0.id 
left join block b1_0 on (b1_0.blocker_id=t1_0.member_id or b1_0.blocker_id=p1_0.owner_id) 
and b1_0.blocked_id=? or b1_0.blocker_id=? 
and (b1_0.blocked_id=t1_0.member_id or b1_0.blocked_id=p1_0.owner_id) 
where p1_0.owner_id=? 
and p1_0.status=? 
and p1_0.post_status=? 
group by p1_0.id 
having count(b1_0.id)=? 
order by p1_0.allowed_date desc
```

references 
- https://hstory0208.tistory.com/entry/QueryDSL-%ED%8E%98%EC%9D%B4%EC%A7%95-%EC%B2%98%EB%A6%AC
- https://junuuu.tistory.com/549
`fetch().size()`
- https://jaeseo.tistory.com/entry/Pageable-%EC%BB%A4%EC%8A%A4%ED%85%80-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%ACfeat-PageableDefault
페이지네이션 예외처리 관련
- https://velog.io/@youngerjesus/%EC%9A%B0%EC%95%84%ED%95%9C-%ED%98%95%EC%A0%9C%EB%93%A4%EC%9D%98-Querydsl-%ED%99%9C%EC%9A%A9%EB%B2%95
페이징 성능을 위해 no offset 사용하기
