### PR TITLE
[refactor/#77-home-tab] 홈탭 게시물 조회 쿼리 리팩토링

### DIFF
--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -18,6 +18,7 @@ import static com.apps.pochak.block.domain.QBlock.block;
 import static com.apps.pochak.follow.domain.QFollow.follow;
 import static com.apps.pochak.global.BaseEntityStatus.ACTIVE;
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
+import static com.apps.pochak.post.domain.PostStatus.PUBLIC;
 import static com.apps.pochak.post.domain.QPost.post;
 import static com.apps.pochak.tag.domain.QTag.tag;
 
@@ -78,6 +79,7 @@ public class PostCustomRepository {
                         tag.post.eq(post)
                                 .and(tag.status.eq(ACTIVE))
                                 .and(post.status.eq(ACTIVE))
+                                .and(post.postStatus.eq(PUBLIC))
                 )
                 .leftJoin(follow).on(checkFollowOwnerOrTaggedMember(memberId))
                 .leftJoin(block).on(checkBlockStatus(memberId))

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -82,6 +82,7 @@ public class PostCustomRepository {
                 .leftJoin(block).on(checkBlockStatus(memberId))
                 .where(
                         follow.id.isNotNull()
+                                .or(block.id.isNotNull())
                                 .or(post.owner.id.eq(memberId))
                                 .or(tag.member.id.eq(memberId))
                 )

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -1,16 +1,22 @@
 package com.apps.pochak.post.domain.repository;
 
-import com.apps.pochak.global.BaseEntityStatus;
 import com.apps.pochak.global.api_payload.exception.GeneralException;
 import com.apps.pochak.post.domain.Post;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.apps.pochak.block.domain.QBlock.block;
+import static com.apps.pochak.follow.domain.QFollow.follow;
+import static com.apps.pochak.global.BaseEntityStatus.ACTIVE;
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.BLOCKED_POST;
 import static com.apps.pochak.post.domain.QPost.post;
 import static com.apps.pochak.tag.domain.QTag.tag;
@@ -35,18 +41,71 @@ public class PostCustomRepository {
                 query.selectFrom(post)
                         .join(post.owner).fetchJoin()
                         .join(tag).on(tag.post.eq(post))
-                        .leftJoin(block).on(
-                                checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
-                                        .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId))
-                        )
+                        .leftJoin(block).on(checkBlockStatus(loginMemberId))
                         .groupBy(post)
                         .having(block.id.count().eq(0L))
                         .where(
                                 post.id.eq(postId),
-                                post.status.eq(BaseEntityStatus.ACTIVE)
+                                post.status.eq(ACTIVE)
                         )
                         .fetchOne()
         );
+    }
+
+    public Page<Post> findPostOfFollowing(
+            final Long memberId,
+            final Pageable pageable
+    ) {
+        List<Post> postList = findPostOfFollowing(memberId)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // TODO: 이게 최선인지.. 확인하기
+        Long count = query
+                .select(post.count())
+                .from(post)
+                .where(post.in(findPostOfFollowing(memberId)))
+                .fetchOne();
+
+        return new PageImpl<>(postList, pageable, count);
+    }
+
+    private JPQLQuery<Post> findPostOfFollowing(final Long memberId) {
+        return query
+                .selectFrom(post)
+                .join(tag).on(
+                        tag.post.eq(post)
+                                .and(tag.status.eq(ACTIVE))
+                                .and(post.status.eq(ACTIVE))
+                )
+                .leftJoin(follow).on(checkFollowOwnerOrTaggedMember(memberId))
+                .leftJoin(block).on(checkBlockStatus(memberId))
+                .groupBy(post)
+                .having((follow.id.count().gt(0L).or(post.owner.id.eq(memberId).or(tag.member.id.eq(memberId))))
+                        .and(block.id.count().eq(0L)))
+                .orderBy(post.allowedDate.desc());
+    }
+
+    private BooleanExpression checkFollowOwnerOrTaggedMember(final Long memberId) {
+        return checkFollowOwner(memberId).or(checkFollowTaggedMember(memberId));
+    }
+
+    private BooleanExpression checkFollowOwner(final Long loginMemberId) {
+        return follow.receiver.eq(post.owner)
+                .and(follow.sender.id.eq(loginMemberId))
+                .and(follow.status.eq(ACTIVE));
+    }
+
+    private BooleanExpression checkFollowTaggedMember(final Long loginMemberId) {
+        return follow.receiver.eq(tag.member)
+                .and(follow.sender.id.eq(loginMemberId))
+                .and(follow.status.eq(ACTIVE));
+    }
+
+    private BooleanExpression checkBlockStatus(final Long loginMemberId) {
+        return checkOwnerOrTaggedMemberBlockLoginMember(loginMemberId)
+                .or(checkLoginMemberBlockOwnerOrTaggedMember(loginMemberId));
     }
 
     private BooleanExpression checkOwnerOrTaggedMemberBlockLoginMember(final Long loginMemberId) {

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -43,8 +43,8 @@ public class PostCustomRepository {
                         .join(post.owner).fetchJoin()
                         .join(tag).on(
                                 tag.post.eq(post)
-                                        .and(checkPublicPost())
                                         .and(post.id.eq(postId))
+                                        .and(checkPublicPost())
                         )
                         .leftJoin(block).on(checkBlockStatus(loginMemberId))
                         .groupBy(post)

--- a/src/main/java/com/apps/pochak/post/service/PostService.java
+++ b/src/main/java/com/apps/pochak/post/service/PostService.java
@@ -57,8 +57,7 @@ public class PostService {
             final Accessor accessor,
             final Pageable pageable
     ) {
-        final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
-        final Page<Post> taggedPost = postRepository.findTaggedPostsOfFollowing(loginMember, pageable);
+        final Page<Post> taggedPost = postCustomRepository.findPostOfFollowing(accessor.getMemberId(), pageable);
         return PostElements.from(taggedPost);
     }
 

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -97,14 +97,10 @@ class PostCustomRepositoryTest {
     void findById_WhenOwnerBlockLoginMember() throws Exception {
         //given
         SavedPostData savedPostData = savePost();
-        Member owner = savedPostData.getOwner();
         Member loginMember = savedPostData.getLoginMember();
         Post savedPost = savedPostData.getSavedPost();
 
-        blockRepository.save(new Block(
-                owner,
-                loginMember
-        ));
+        block(savedPostData.getOwner(), loginMember);
 
         //when
         GeneralException exception = assertThrows(
@@ -125,10 +121,7 @@ class PostCustomRepositoryTest {
         Member loginMember = savedPostData.getLoginMember();
         Post savedPost = savedPostData.getSavedPost();
 
-        blockRepository.save(new Block(
-                taggedMember1,
-                loginMember
-        ));
+        block(taggedMember1, loginMember);
 
         //when
         GeneralException exception = assertThrows(
@@ -146,13 +139,9 @@ class PostCustomRepositoryTest {
         //given
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
-        Member owner = savedPostData.getOwner();
         Post savedPost = savedPostData.getSavedPost();
 
-        blockRepository.save(new Block(
-                loginMember,
-                owner
-        ));
+        block(loginMember, savedPostData.getOwner());
 
         //when
         GeneralException exception = assertThrows(
@@ -170,13 +159,9 @@ class PostCustomRepositoryTest {
         //given
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
-        Member taggedMember1 = savedPostData.getTaggedMember1();
         Post savedPost = savedPostData.getSavedPost();
 
-        blockRepository.save(new Block(
-                loginMember,
-                taggedMember1
-        ));
+        block(loginMember, savedPostData.getTaggedMember1());
 
         //when
         GeneralException exception = assertThrows(
@@ -213,12 +198,11 @@ class PostCustomRepositoryTest {
         //given
         SavedPostData savedPostData = savePost();
         Post savedPost = savedPostData.getSavedPost();
-        savedPost.makePublic();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPost.getOwner());
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -236,12 +220,11 @@ class PostCustomRepositoryTest {
         //given
         SavedPostData savedPostData = savePost();
         Post savedPost = savedPostData.getSavedPost();
-        savedPost.makePublic();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getTaggedMember1());
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -260,10 +243,10 @@ class PostCustomRepositoryTest {
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getTaggedMember1());
         block(savedPostData.getOwner(), loginMember);
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -282,10 +265,10 @@ class PostCustomRepositoryTest {
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getOwner());
         block(savedPostData.getTaggedMember1(), loginMember);
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -304,10 +287,10 @@ class PostCustomRepositoryTest {
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getTaggedMember1());
         block(savedPostData.getTaggedMember2(), loginMember);
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -326,10 +309,10 @@ class PostCustomRepositoryTest {
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getTaggedMember1());
         block(loginMember, savedPostData.getOwner());
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -348,10 +331,10 @@ class PostCustomRepositoryTest {
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getOwner());
         block(loginMember, savedPostData.getTaggedMember1());
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)
@@ -370,10 +353,10 @@ class PostCustomRepositoryTest {
         SavedPostData savedPostData = savePost();
         Member loginMember = savedPostData.getLoginMember();
 
-        //when
         follow(loginMember, savedPostData.getTaggedMember1());
         block(loginMember, savedPostData.getTaggedMember2());
 
+        //when
         Page<Post> postPage = postCustomRepository.findPostOfFollowing(
                 loginMember.getId(),
                 PageRequest.of(0, DEFAULT_PAGING_SIZE)

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -192,6 +192,56 @@ class PostCustomRepositoryTest {
         //then
         assertEquals(BLOCKED_POST, exception.getCode());
     }
+
+    @DisplayName("[홈탭 조회] 차단된 게시물을 제외한 홈 탭 게시물이 조회된다.")
+    @Test
+    void findPostOfFollowing() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("[홈탭 조회] 게시물을 업로드한 사람이 현재 로그인한 사람을 차단하였다면 해당 게시물은 제외되어 조회된다.")
+    @Test
+    void findPostOfFollowing_WhenOwnerBlockLoginMember() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("[홈탭 조회] 게시물에 태그된 사람 중 한명이라도 현재 로그인한 사람을 차단하였다면 해당 게시물은 제외되어 조회된다.")
+    @Test
+    void findPostOfFollowing_WhenTaggedMemberBlockLoginMember() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("[홈탭 조회] 현재 로그인한 사람이 게시물을 업로드한 사람을 차단하였다면 해당 게시물은 제외되어 조회된다.")
+    @Test
+    void findPostOfFollowing_WhenLoginMemberBlockOwner() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
+
+    @DisplayName("[홈탭 조회] 현재 로그인한 사람이 게시물에 태그된 사람 중 한명이라도 차단하였다면 해당 게시물은 제외되어 조회된다.")
+    @Test
+    void findPostOfFollowing_WhenLoginMemberBlockTaggedMember() throws Exception{
+        //given
+
+        //when
+
+        //then
+    }
 }
 
 @Data


### PR DESCRIPTION
## 📒 개요

홈탭의 게시물을 조회하는 `findPostOfFollowing()` 함수의 쿼리를 리팩토링함

## 📍 Issue 번호

- #77 

## 🛠️ 작업사항

- [x] 쿼리 리팩토링
    - 기존에 BLOCK 로직이 없어서 이것도 추가함 
- [x] 테스트

## 🧰 추가 논의사항

- JOIN 을 이렇게 여러번 쓰는게 최선인가? JOIN 1번, LEFT JOIN 2번..
- 쿼리에 조건 부분이 너무 긴 것 같아서 기존에 있는 코드를 더 리팩토링해서 씀 `checkBlockStatus()` 참고
- 페이징에 count() 쿼리 부분.. 일단 저렇게 썼는데, 이게 최선인가?
    - from절에 서브 쿼리가 가능했다면.. from에 넣고 select(post.count()) 이런식으로 해결하려 했으나,... 서브쿼리가 안들어감😥
    - 그래서 저렇게 씀
