### PR TITLE
[Fix/#79-NFE] 인증되지 않은 사용자가 접근할 경우 예외처리합니다

### DIFF
--- a/src/main/java/com/apps/pochak/login/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/apps/pochak/login/filter/JwtAuthorizationFilter.java
@@ -2,6 +2,7 @@ package com.apps.pochak.login.filter;
 
 import com.apps.pochak.global.api_payload.code.ErrorReasonDTO;
 import com.apps.pochak.global.api_payload.exception.GeneralException;
+import com.apps.pochak.global.api_payload.exception.handler.InvalidJwtException;
 import com.apps.pochak.login.provider.JwtProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
@@ -17,7 +18,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import static com.apps.pochak.global.Constant.*;
+import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.NULL_TOKEN;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -53,6 +54,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                         Authentication authentication = getAuthentication(accessToken);
                         SecurityContextHolder.getContext().setAuthentication(authentication);
                     }
+                } else {
+                    throw new InvalidJwtException(NULL_TOKEN);
                 }
                 filterChain.doFilter(request, response);
             } catch (GeneralException e) {


### PR DESCRIPTION
## 📒 개요

인증 요청 외 특정 url에 접근할 때 토큰이 없으면 스프링시큐리티가 기본적으로 익명토큰을 넣어주는데 @Auth accessor이걸 받아와야하다보니 resolver에서 Accessor리턴해주려다가 anonymousUser를 파싱을 못해서 에러 발생

```
if (servletPath.equals("/api/v2/refresh")) {
            filterChain.doFilter(request, response);
        } else {
            try {
                if (headerValue != null && headerValue.startsWith(TOKEN_PREFIX)) {
                    String accessToken = headerValue.substring(TOKEN_PREFIX.length());
                    if (jwtProvider.validateAccessToken(accessToken)) {
                        Authentication authentication = getAuthentication(accessToken);
                        SecurityContextHolder.getContext().setAuthentication(authentication);
                    }
                } 
                filterChain.doFilter(request, response);
            } catch (GeneralException e) {
                exceptionHandler(response, e);
            }
        }
```
headerValue가 null일 때 filterChain.doFilter(request, response);이 실행되는 것을 막고자 함

## 📍 Issue 번호

- #79 

## 🛠️ 작업사항

- [x] headerValue가 null일 때 throw new InvalidJwtException(NULL_TOKEN); 오류 던짐

## 🧰 추가 논의사항

- 프론트 테스트 필요
