### PR TITLE
[Fix/#79-NFE-bug] LoginArgumentResolver에서 NFE 예외처리하기

### DIFF
--- a/src/main/java/com/apps/pochak/login/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/apps/pochak/login/filter/JwtAuthorizationFilter.java
@@ -54,8 +54,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                         Authentication authentication = getAuthentication(accessToken);
                         SecurityContextHolder.getContext().setAuthentication(authentication);
                     }
-                } else {
-                    throw new InvalidJwtException(NULL_TOKEN);
                 }
                 filterChain.doFilter(request, response);
             } catch (GeneralException e) {

--- a/src/main/java/com/apps/pochak/login/util/LoginArgumentResolver.java
+++ b/src/main/java/com/apps/pochak/login/util/LoginArgumentResolver.java
@@ -2,7 +2,7 @@ package com.apps.pochak.login.util;
 
 import com.apps.pochak.auth.Auth;
 import com.apps.pochak.auth.domain.Accessor;
-import com.apps.pochak.login.provider.JwtProvider;
+import com.apps.pochak.global.api_payload.exception.handler.AuthenticationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,6 +11,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.apps.pochak.global.api_payload.code.status.ErrorStatus._INVALID_AUTHORITY;
 
 @RequiredArgsConstructor
 @Component
@@ -30,7 +32,11 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
             final WebDataBinderFactory binderFactory
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        final Long memberId = Long.valueOf(principal.toString());
-        return Accessor.member(memberId);
+        try {
+            final Long memberId = Long.valueOf(principal.toString());
+            return Accessor.member(memberId);
+        } catch (NumberFormatException e) {
+            throw new AuthenticationException(_INVALID_AUTHORITY);
+        }
     }
 }


### PR DESCRIPTION
## 📒 개요

헤더가 비어도 접근 가능해야 하는 페이지들이 있기 때문에 오류가 발생함
따라서 anonymousUser의 경우 파싱 에러가 나는 LoginArgumentResolver에서 NFE에러 발생시 접근불가 예외를 던져주었다

## 📍 Issue 번호

- #79 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] LoginArgumentResolver에서 NFE 예외처리하기

## 🧰 추가 논의사항

- 내용을 적어주세요.
