### PR TITLE
[Refactor/#93-alarm-column] LikeAlarm 컬럼명 수정하기

### DIFF
--- a/src/main/java/com/apps/pochak/alarm/domain/LikeAlarm.java
+++ b/src/main/java/com/apps/pochak/alarm/domain/LikeAlarm.java
@@ -21,8 +21,8 @@ public class LikeAlarm extends Alarm {
     @JoinColumn(name = "like_id")
     private LikeEntity like;
 
-    private Long likedPostId;
-    private String likedPostImage;
+    private Long postId;
+    private String postImage;
 
     public LikeAlarm(
             final Long id,
@@ -47,7 +47,7 @@ public class LikeAlarm extends Alarm {
         this.like = like;
 
         Post likedPost = like.getLikedPost();
-        this.likedPostId = likedPost.getId();
-        this.likedPostImage = likedPost.getPostImage();
+        this.postId = likedPost.getId();
+        this.postImage = likedPost.getPostImage();
     }
 }

--- a/src/main/java/com/apps/pochak/alarm/domain/repository/AlarmRepository.java
+++ b/src/main/java/com/apps/pochak/alarm/domain/repository/AlarmRepository.java
@@ -130,7 +130,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     @Modifying
     @Query(value = """
             update alarm a set a.status = 'DELETED'
-                   where a.post_id = :postId or a.liked_post_id = :postId
+                   where a.post_id = :postId
             """,
             nativeQuery = true)
     void deleteByPost(@Param("postId") final Long postId);

--- a/src/main/java/com/apps/pochak/alarm/dto/response/alarm_element/LikeAlarmElement.java
+++ b/src/main/java/com/apps/pochak/alarm/dto/response/alarm_element/LikeAlarmElement.java
@@ -22,7 +22,7 @@ public class LikeAlarmElement extends AlarmElement {
         this.memberHandle = alarm.getSender().getHandle();
         this.memberName = alarm.getSender().getName();
         this.memberProfileImage = alarm.getSender().getProfileImage();
-        this.postId = alarm.getLikedPostId();
-        this.postImage = alarm.getLikedPostImage();
+        this.postId = alarm.getPostId();
+        this.postImage = alarm.getPostImage();
     }
 }


### PR DESCRIPTION
## 📒 개요

LikeAlarm의 likedPostId와 likedPostImage의 컬럼명을 다른 Alarm엔티티와 같이 postId와 postImage로 변경하였습니다

## 📍 Issue 번호

- #93 

## 🛠️ 작업사항

- [x] 코드 변경
- [x] 데이터 변경
- [ ] DB 적용

## 🧰 추가 논의사항

- ![image](https://github.com/user-attachments/assets/2d810a51-5a07-4eca-bf58-44384980f89a)
DB를 정리하려고 했으나, 표시한 기존 column들을 남겨두는 게 맞는가 싶습니다.
LikeAlarm과 LikeEntity가 중복되는 게 좀 있어서 여기도 정리하면 좋을 것 같아요!