### PR TITLE
[Refactor/#67-postrepo-querydsl] 메소드 순서 및 정리

### DIFF
--- a/src/main/java/com/apps/pochak/member/service/MemberService.java
+++ b/src/main/java/com/apps/pochak/member/service/MemberService.java
@@ -100,7 +100,7 @@ public class MemberService {
     ) {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Member owner = memberRepository.findByHandle(handle, loginMember);
-        final Page<Post> taggedPost = postCustomRepository.findUploadPostPage(owner, accessor.getMemberId(), pageable);
+        final Page<Post> taggedPost = postCustomRepository.findUploadPost(owner, accessor.getMemberId(), pageable);
         return PostElements.from(taggedPost);
     }
 

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostCustomRepository.java
@@ -66,13 +66,12 @@ public class PostCustomRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count = query
+        JPAQuery<Long> countQuery = query
                 .select(post.count())
                 .from(post)
-                .where(post.in(findPostOfFollowing(memberId)))
-                .fetchOne();
+                .where(post.in(findPostOfFollowing(memberId)));
 
-        return new PageImpl<>(postList, pageable, count);
+        return PageableExecutionUtils.getPage(postList, pageable, countQuery::fetchOne);
     }
 
     private JPQLQuery<Post> findPostOfFollowing(final Long memberId) {
@@ -99,7 +98,7 @@ public class PostCustomRepository {
             final Long loginMemberId,
             final Pageable pageable
     ) {
-        List<Post> contentPage = findUploadPost(owner, loginMemberId)
+        List<Post> postList = findUploadPost(owner, loginMemberId)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -108,7 +107,7 @@ public class PostCustomRepository {
                 .from(post)
                 .where(post.in(findUploadPost(owner, loginMemberId)));
 
-        return PageableExecutionUtils.getPage(contentPage, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(postList, pageable, countQuery::fetchOne);
     }
 
     private JPAQuery<Post> findUploadPost(

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
@@ -49,19 +49,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             final Pageable pageable
     );
 
-    @Query("select p from Post p " +
-            "where p.owner = :owner and p.status = 'ACTIVE' and p.postStatus = 'PUBLIC' " +
-            "   and p.owner not in (select b.blockedMember from Block b where b.blocker = :loginMember) " +
-            "   and :loginMember not in (select b.blockedMember from Block b where b.blocker = p.owner) " +
-            "   and not exists (select t.member from Tag t where t.post = p intersect select b.blockedMember from Block b where b.blocker = :loginMember) " +
-            "   and :loginMember not in (select b.blockedMember from Block b where b.blocker in (select t.member from Tag t where t.post = p)) " +
-            "order by p.createdDate desc ")
-    Page<Post> findUploadPost(
-            @Param("owner") final Member owner,
-            @Param("loginMember") final Member loginMember,
-            final Pageable pageable
-    );
-
     @Query("select distinct p from Post p " +
             "join Tag t on p = t.post and p.postStatus = 'PUBLIC' and t.status = 'ACTIVE' and " +
             "   ( " +

--- a/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/post/domain/repository/PostCustomRepositoryTest.java
@@ -13,7 +13,6 @@ import com.apps.pochak.member.fixture.MemberFixture;
 import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.domain.repository.TagRepository;
-import jakarta.persistence.EntityManager;
 import lombok.Builder;
 import lombok.Data;
 import org.junit.jupiter.api.DisplayName;
@@ -43,9 +42,6 @@ class PostCustomRepositoryTest {
     private static final Member TAGGED_MEMBER1 = MemberFixture.TAGGED_MEMBER1;
     private static final Member TAGGED_MEMBER2 = MemberFixture.TAGGED_MEMBER2;
     private static final Member LOGIN_MEMBER = MemberFixture.LOGIN_MEMBER;
-
-    @Autowired
-    private EntityManager em;
 
     @Autowired
     PostCustomRepository postCustomRepository;
@@ -182,7 +178,7 @@ class PostCustomRepositoryTest {
 
     @Test
     @DisplayName("[프로필 포착 게시물 조회] 현재 로그인한 사람이 특정 포차커가 업로드한 게시물을 페이지별로 조회한다.")
-    void findUploadPostPage() {
+    void findUploadPost() {
         //given
         SavedPostData savedPostData = savePost();
         Member owner = savedPostData.getOwner();
@@ -191,7 +187,7 @@ class PostCustomRepositoryTest {
         savedPostData.getSavedPost().setStatus(BaseEntityStatus.ACTIVE);
 
         //when
-        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember.getId(), PageRequest.of(0, 1));
+        Page<Post> posts = postCustomRepository.findUploadPost(owner, loginMember.getId(), PageRequest.of(0, 1));
 
         //then
         assertThat(posts.getTotalElements()).isEqualTo(1L);
@@ -200,7 +196,7 @@ class PostCustomRepositoryTest {
 
     @Test
     @DisplayName("[프로필 포착 게시물 조회] 현재 로그인한 사람이 게시물 작성자가 태그한 사람 중 한 명이라도 차단했을시 그 게시물은 조회되지 않는다.")
-    void findUploadPostPageWithoutBlockPostWhenLoginMemberBlockTaggedMember() {
+    void findUploadPostWithoutBlockPostWhenLoginMemberBlockTaggedMember() {
         //given
         SavedPostData savedPostData = savePost();
         Member owner = savedPostData.getOwner();
@@ -211,7 +207,7 @@ class PostCustomRepositoryTest {
         block(loginMember, savedPostData.getTaggedMember1());
 
         //when
-        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember.getId(), PageRequest.of(0, 1));
+        Page<Post> posts = postCustomRepository.findUploadPost(owner, loginMember.getId(), PageRequest.of(0, 1));
         //then
         assertThat(posts.getTotalElements()).isEqualTo(0L);
         assertFalse((posts).hasContent());
@@ -219,7 +215,7 @@ class PostCustomRepositoryTest {
 
     @Test
     @DisplayName("[프로필 포착 게시물 조회] 현재 로그인한 사람이 게시물 작성자가 태그한 사람 중 한 명에게라도 차단당했을시 그 게시물은 조회되지 않는다.")
-    void findUploadPostPageWithoutBlockPostWhenTaggedMemberBlockLoginMember() {
+    void findUploadPostWithoutBlockPostWhenTaggedMemberBlockLoginMember() {
         //given
         SavedPostData savedPostData = savePost();
         Member owner = savedPostData.getOwner();
@@ -230,7 +226,7 @@ class PostCustomRepositoryTest {
         block(savedPostData.getTaggedMember1(), loginMember);
 
         //when
-        Page<Post> posts = postCustomRepository.findUploadPostPage(owner, loginMember.getId(), PageRequest.of(0, 1));
+        Page<Post> posts = postCustomRepository.findUploadPost(owner, loginMember.getId(), PageRequest.of(0, 1));
         //then
         assertThat(posts.getTotalElements()).isEqualTo(0L);
         assertFalse((posts).hasContent());


### PR DESCRIPTION
## 📒 개요

회의 때 정한 컨벤션대로 수정하고 테스트했습니다!

## 📍 Issue 번호

- #67 

## 🛠️ 작업사항

- [x] public > private
- [x] 변수명 정리
- [x] checkPublic() 메소드있길래 upload에도 적용했습니다

## 🧰 추가 논의사항

- check 메소드들 최적화