### PR TITLE
[Fix/#104-memories-npe] 추억페이지 null값으로 dto 리턴

### DIFF
--- a/src/main/java/com/apps/pochak/memories/dto/MemoriesElement.java
+++ b/src/main/java/com/apps/pochak/memories/dto/MemoriesElement.java
@@ -16,6 +16,9 @@ public class MemoriesElement {
     private LocalDateTime postDate;
 
     public static MemoriesElement from(final Tag tag) {
+        if (tag == null) {
+            return new MemoriesElement(null, null, null);
+        }
         return new MemoriesElement(tag.getPost().getId(), tag.getPost().getPostImage(), tag.getPost().getAllowedDate());
     }
 }

--- a/src/main/java/com/apps/pochak/memories/dto/MemoriesElement.java
+++ b/src/main/java/com/apps/pochak/memories/dto/MemoriesElement.java
@@ -17,7 +17,7 @@ public class MemoriesElement {
 
     public static MemoriesElement from(final Tag tag) {
         if (tag == null) {
-            return new MemoriesElement(null, null, null);
+            return new MemoriesElement();
         }
         return new MemoriesElement(tag.getPost().getId(), tag.getPost().getPostImage(), tag.getPost().getAllowedDate());
     }

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -62,8 +62,8 @@ public class MemoriesPreviewResponse {
 
     private int findFollowDay(LocalDateTime followDate, LocalDateTime followedDate) {
         if (followDate.isAfter(followedDate)) {
-            return Period.between(LocalDate.now(), followDate.toLocalDate()).getDays();
+            return Period.between(followDate.toLocalDate(), LocalDate.now()).getDays();
         } else
-            return Period.between(LocalDate.now(), followedDate.toLocalDate()).getDays();
+            return Period.between(followedDate.toLocalDate(), LocalDate.now()).getDays();
     }
 }


### PR DESCRIPTION
## 📒 개요

하나의 요소가 null이라고 해서 예외를 던지면 안돼서 null값으로 전송하는 방향으로 수정했습니다.

## 📍 Issue 번호

- #104 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] dto element null처리하기
- [x] api 테스트 하다보니 followDay가 음수로 나오길래 양수로 나오도록 수정했습니다

## 🧰 추가 논의사항

- 내용을 적어주세요.
