### PR TITLE
[Refactor/#109-like-entity-column] LikeEntity 컬럼명 변경

### DIFF
--- a/src/main/java/com/apps/pochak/alarm/domain/LikeAlarm.java
+++ b/src/main/java/com/apps/pochak/alarm/domain/LikeAlarm.java
@@ -30,7 +30,7 @@ public class LikeAlarm extends Alarm {
             final Member receiver,
             final AlarmType alarmType
     ) {
-        super(id, receiver, alarmType, like.getLikeMember());
+        super(id, receiver, alarmType, like.getMember());
         initializeFields(like);
     }
 
@@ -39,14 +39,14 @@ public class LikeAlarm extends Alarm {
             final Member receiver,
             final AlarmType alarmType
     ) {
-        super(receiver, alarmType, like.getLikeMember());
+        super(receiver, alarmType, like.getMember());
         initializeFields(like);
     }
 
     private void initializeFields(LikeEntity like) {
         this.like = like;
 
-        Post likedPost = like.getLikedPost();
+        Post likedPost = like.getPost();
         this.postId = likedPost.getId();
         this.postImage = likedPost.getPostImage();
     }

--- a/src/main/java/com/apps/pochak/alarm/service/LikeAlarmService.java
+++ b/src/main/java/com/apps/pochak/alarm/service/LikeAlarmService.java
@@ -47,7 +47,7 @@ public class LikeAlarmService {
     private void sendTaggedPostLikeAlarm(
             final LikeEntity like
     ) {
-        final List<Tag> tagList = tagRepository.findTagsByPost(like.getLikedPost());
+        final List<Tag> tagList = tagRepository.findTagsByPost(like.getPost());
 
         final List<Alarm> alarmList = new ArrayList<>();
         for (Tag tag : tagList) {
@@ -68,7 +68,7 @@ public class LikeAlarmService {
             final LikeEntity like,
             final Member receiver
     ) {
-        return like.getLikeMember().equals(receiver);
+        return like.getMember().equals(receiver);
     }
 
     public void deleteAlarmByLike(final LikeEntity like) {

--- a/src/main/java/com/apps/pochak/like/domain/LikeEntity.java
+++ b/src/main/java/com/apps/pochak/like/domain/LikeEntity.java
@@ -25,16 +25,16 @@ public class LikeEntity extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "like_member_id")
-    private Member likeMember;
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "liked_post_id")
-    private Post likedPost;
+    @JoinColumn(name = "post_id")
+    private Post post;
 
     @Builder
-    public LikeEntity(Member likeMember, Post likedPost) {
-        this.likeMember = likeMember;
-        this.likedPost = likedPost;
+    public LikeEntity(Member member, Post post) {
+        this.member = member;
+        this.post = post;
     }
 }

--- a/src/main/java/com/apps/pochak/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/apps/pochak/like/domain/repository/LikeRepository.java
@@ -14,19 +14,19 @@ import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
-    @Query("select count(l) from LikeEntity l where l.likedPost = :post and l.status = 'ACTIVE'")
-    int countByLikedPost(@Param("post") final Post post);
+    @Query("select count(l) from LikeEntity l where l.post = :post and l.status = 'ACTIVE'")
+    int countByPost(@Param("post") final Post post);
 
     @Query("select count(l) > 0 from LikeEntity l " +
-            "where l.likeMember = :member " +
-            "   and l.likedPost = :post " +
+            "where l.member = :member " +
+            "   and l.post = :post " +
             "   and l.status = 'ACTIVE'")
-    Boolean existsByLikeMemberAndLikedPost(
+    Boolean existsByMemberAndPost(
             @Param("member") final Member member,
             @Param("post") final Post post
     );
 
-    Optional<LikeEntity> findByLikeMemberAndLikedPost(
+    Optional<LikeEntity> findByMemberAndPost(
             final Member member,
             final Post post
     );
@@ -43,11 +43,11 @@ public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
             "   (case when m.id <> :loginMemberId then (f.sender is not null) else nullif(m.id, :loginMemberId) end) " +
             ") " +
             "from LikeEntity l " +
-            "join Member m on (l.likedPost = :post and l.likeMember = m and m.status = 'ACTIVE'" +
+            "join Member m on (l.post = :post and l.member = m and m.status = 'ACTIVE'" +
             "                       and m not in (select b.blockedMember from Block b where b.blocker.id = :loginMemberId) " +
             "                       and :loginMemberId not in (select b.blockedMember.id from Block b where b.blocker = m)) " +
-            "left join Follow f on (f.sender.id = :loginMemberId and f.receiver = l.likeMember) and f.status = 'ACTIVE' " +
-            "where l.status = 'ACTIVE' and l.likedPost = :post " +
+            "left join Follow f on (f.sender.id = :loginMemberId and f.receiver = l.member) and f.status = 'ACTIVE' " +
+            "where l.status = 'ACTIVE' and l.post = :post " +
             "order by f.lastModifiedDate desc ")
     List<LikeElement> findLikesAndIsFollow(
             @Param("loginMemberId") final Long loginMemberId,
@@ -57,10 +57,10 @@ public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
     @Modifying
     @Query("update LikeEntity l " +
             "set l.status = 'DELETED' " +
-            "where (l.likeMember = :memberA and l.likedPost.id in (select p.id from Post p where p.owner = :memberB))" +
-            "   or (l.likeMember = :memberB and l.likedPost.id in (select p.id from Post p where p.owner = :memberA))" +
-            "   or (l.likeMember = :memberA and l.likedPost.id in (select t.post.id from Tag t where t.member = :memberB))" +
-            "   or (l.likeMember = :memberB and l.likedPost.id in (select t.post.id from Tag t where t.member = :memberA))")
+            "where (l.member = :memberA and l.post.id in (select p.id from Post p where p.owner = :memberB))" +
+            "   or (l.member = :memberB and l.post.id in (select p.id from Post p where p.owner = :memberA))" +
+            "   or (l.member = :memberA and l.post.id in (select t.post.id from Tag t where t.member = :memberB))" +
+            "   or (l.member = :memberB and l.post.id in (select t.post.id from Tag t where t.member = :memberA))")
     void deleteLikesBetweenMembers(
             @Param("memberA") final Member memberA,
             @Param("memberB") final Member memberB
@@ -69,7 +69,7 @@ public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
     @Modifying
     @Query(value = """
             update like_entity l, alarm a set l.status = 'DELETED', a.status = 'DELETED'
-            where (l.like_member_id = :memberId or l.liked_post_id in :postIdList)
+            where (l.member_id = :memberId or l.post_id in :postIdList)
                 and l.id = a.like_id
             """,
             nativeQuery = true)
@@ -79,5 +79,5 @@ public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
     );
 
     @Modifying
-    void deleteByLikedPost(Post post);
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/apps/pochak/like/service/LikeService.java
+++ b/src/main/java/com/apps/pochak/like/service/LikeService.java
@@ -36,7 +36,7 @@ public class LikeService {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Post post = postRepository.findPostById(postId);
 
-        final Optional<LikeEntity> optionalLike = likeRepository.findByLikeMemberAndLikedPost(loginMember, post);
+        final Optional<LikeEntity> optionalLike = likeRepository.findByMemberAndPost(loginMember, post);
         if (optionalLike.isPresent()) {
             final LikeEntity postLike = optionalLike.get();
             toggleLikeStatus(postLike);
@@ -54,7 +54,7 @@ public class LikeService {
             likeAlarmService.deleteAlarmByLike(like);
         } else {
             like.setStatus(ACTIVE);
-            likeAlarmService.sendLikeAlarm(like, like.getLikedPost().getOwner());
+            likeAlarmService.sendLikeAlarm(like, like.getPost().getOwner());
         }
     }
 
@@ -63,8 +63,8 @@ public class LikeService {
             final Post post
     ) {
         final LikeEntity like = LikeEntity.builder()
-                .likeMember(loginMember)
-                .likedPost(post)
+                .member(loginMember)
+                .post(post)
                 .build();
         likeRepository.save(like);
         likeAlarmService.sendLikeAlarm(like, post.getOwner());

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
@@ -118,7 +118,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Long> findPostIdListByOwnerOrTaggedMember(@Param("member") final Member member);
 
     @Query("select p from Post p " +
-            "left join LikeEntity l on l.likedPost = p " +
+            "left join LikeEntity l on l.post = p " +
             "where p.postStatus = 'PUBLIC' and p.status = 'ACTIVE' " +
             "group by p.id " +
             "order by count(l) desc, p.allowedDate desc ")

--- a/src/main/java/com/apps/pochak/post/service/PostService.java
+++ b/src/main/java/com/apps/pochak/post/service/PostService.java
@@ -71,8 +71,8 @@ public class PostService {
         final List<Tag> tagList = tagRepository.findTagsByPost(post);
         final Boolean isFollow = post.isOwner(loginMember) ?
                 null : followRepository.existsBySenderAndReceiver(loginMember, post.getOwner());
-        final Boolean isLike = likeRepository.existsByLikeMemberAndLikedPost(loginMember, post);
-        final int likeCount = likeRepository.countByLikedPost(post);
+        final Boolean isLike = likeRepository.existsByMemberAndPost(loginMember, post);
+        final int likeCount = likeRepository.countByPost(post);
         final Comment comment = commentRepository.findFirstByPost(post, loginMember).orElse(null);
 
         return PostDetailResponse.of()
@@ -139,7 +139,7 @@ public class PostService {
         postRepository.delete(post);
         commentRepository.deleteByPost(post);
         tagRepository.deleteByPost(post);
-        likeRepository.deleteByLikedPost(post);
+        likeRepository.deleteByPost(post);
         alarmRepository.deleteByPost(post.getId());
     }
 


### PR DESCRIPTION
## 📒 개요

likeMember를 member로 likedPost를 post로 변경

## 📍 Issue 번호

- #109 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] 코드 수정
- [ ] DB 수정

## 🧰 추가 논의사항

- DB 변경 전입니다 머지된 후 바꿔야 할 것 같아서요!
- 이건 그냥 둘러보다가 likeService.getMemberLikedPost -> getMembersLikePost 가 의미상 자연스러울 것 같습니다.
- likeRepo 테스트를 해봐야할까요?
