### PR TITLE
[Refactor/#108-sign-up-validation] 회원가입시 유저 데이터의 유효성을 검사합니다

### DIFF
--- a/src/main/java/com/apps/pochak/login/dto/request/MemberInfoRequest.java
+++ b/src/main/java/com/apps/pochak/login/dto/request/MemberInfoRequest.java
@@ -1,7 +1,7 @@
 package com.apps.pochak.login.dto.request;
 
 import com.apps.pochak.global.annotation.ValidFile;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,13 +13,20 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberInfoRequest {
 
     @NotNull(message = "사용자의 이름은 필수입니다.")
+    @NotBlank(message = "이름은 공백이 될 수 없습니다.")
+    @Size(max = 15, message = "이름은 최대 15자까지 가능합니다.")
     private String name;
 
+    @Email
     private String email;
 
-    @NotNull(message = "사용자의 별명은 필수입니다.")
+    @NotNull(message = "사용자의 핸들은 필수입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9_.]+$", message = "핸들은 대문자, 소문자, 숫자, _(언더바), .(마침표)만 가능합니다.")
+    @Size(max = 15, message = "핸들은 최대 15자까지 가능합니다.")
     private String handle;
 
+    @Pattern(regexp = "^(.+\n?){0,3}$", message = "소개는 최대 3줄까지 가능합니다.")
+    @Size(max = 50, message = "소개는 최대 50자까지 가능합니다.")
     private String message;
 
     @NotNull(message = "사용자의 소셜 아이디는 필수입니다.")

--- a/src/main/java/com/apps/pochak/login/dto/request/MemberInfoRequest.java
+++ b/src/main/java/com/apps/pochak/login/dto/request/MemberInfoRequest.java
@@ -1,6 +1,5 @@
 package com.apps.pochak.login.dto.request;
 
-import com.apps.pochak.global.annotation.ValidFile;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -32,7 +31,6 @@ public class MemberInfoRequest {
     @NotNull(message = "사용자의 소셜 아이디는 필수입니다.")
     private String socialId;
 
-    @ValidFile(message = "프로필 이미지는 필수입니다.")
     private MultipartFile profileImage;
 
     @NotNull(message = "사용자의 소셜 로그인 플랫폼은 필수입니다.")

--- a/src/main/java/com/apps/pochak/login/service/OAuthService.java
+++ b/src/main/java/com/apps/pochak/login/service/OAuthService.java
@@ -49,7 +49,11 @@ public class OAuthService {
         Optional<Member> memberByHandle = memberRepository.findMemberByHandle(memberInfoRequest.getHandle());
         if (memberByHandle.isPresent()) throw new GeneralException(DUPLICATE_HANDLE);
 
-        String profileImageUrl = cloudStorageService.upload(memberInfoRequest.getProfileImage(), MEMBER);
+        String profileImageUrl= null;
+        if (memberInfoRequest.getProfileImage() != null) {
+            profileImageUrl = cloudStorageService.upload(memberInfoRequest.getProfileImage(), MEMBER);
+        }
+
         String refreshToken = jwtProvider.createRefreshToken();
 
         Member member = Member.signupMember()

--- a/src/main/java/com/apps/pochak/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/apps/pochak/member/dto/request/ProfileUpdateRequest.java
@@ -1,5 +1,9 @@
 package com.apps.pochak.member.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,10 +13,14 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProfileUpdateRequest {
+    @NotNull(message = "사용자의 이름은 필수입니다.")
+    @NotBlank(message = "이름은 공백이 될 수 없습니다.")
+    @Size(max = 15, message = "이름은 최대 15자까지 가능합니다.")
     private String name;
 
+    @Pattern(regexp = "^(.+\n?){0,3}$", message = "소개는 최대 3줄까지 가능합니다.")
+    @Size(max = 50, message = "소개는 최대 50자까지 가능합니다.")
     private String message;
 
     private MultipartFile profileImage;
-
 }

--- a/src/main/java/com/apps/pochak/member/service/MemberService.java
+++ b/src/main/java/com/apps/pochak/member/service/MemberService.java
@@ -69,7 +69,9 @@ public class MemberService {
 
         String profileImageUrl = updateMember.getProfileImage();
         if (profileUpdateRequest.getProfileImage() != null) {
-            cloudStorageService.delete(updateMember.getProfileImage());
+            if (profileImageUrl != null) {
+                cloudStorageService.delete(updateMember.getProfileImage());
+            }
             profileImageUrl = cloudStorageService.upload(profileUpdateRequest.getProfileImage(), MEMBER);
         }
 

--- a/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
+++ b/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
@@ -21,6 +21,7 @@ import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.MockMultipartFileConverter.getSampleMultipartFile;
 import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
+import static com.apps.pochak.member.fixture.MemberFixture.WRONG_MEMBER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -41,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @MockBean(JpaMetamodelMappingContext.class)
 public class OAuthControllerTest extends ControllerTest {
     private static final Member MEMBER1 = STATIC_MEMBER1;
+    private static final Member MEMBER2 = WRONG_MEMBER;
 
     @MockBean
     OAuthService oAuthService;
@@ -213,5 +215,31 @@ public class OAuthControllerTest extends ControllerTest {
                                 )
                         )
                 );
+    }
+
+    @Test
+    @DisplayName("회원가입 유효성 검사를 한다.")
+    void signUpValidationTest() throws Exception {
+        when(oAuthService.signup(any()))
+                .thenReturn(
+                        new OAuthMemberResponse(
+                                MEMBER2,
+                                false,
+                                ACCESS_TOKEN
+                        )
+                );
+
+        this.mockMvc.perform(
+                        multipart("/api/v2/signup")
+                                .file("profileImage", null)
+                                .queryParam("name", MEMBER2.getName())
+                                .queryParam("email", MEMBER2.getEmail())
+                                .queryParam("handle", MEMBER2.getHandle())
+                                .queryParam("message", MEMBER2.getMessage())
+                                .queryParam("socialId", MEMBER2.getSocialId())
+                                .queryParam("socialType", MEMBER2.getSocialType().getCode())
+                                .queryParam("socialRefreshToken", MEMBER2.getSocialRefreshToken())
+                                .contentType(APPLICATION_JSON)
+                ).andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
+++ b/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
@@ -220,15 +220,6 @@ public class OAuthControllerTest extends ControllerTest {
     @Test
     @DisplayName("회원가입 유효성 검사를 한다.")
     void signUpValidationTest() throws Exception {
-        when(oAuthService.signup(any()))
-                .thenReturn(
-                        new OAuthMemberResponse(
-                                MEMBER2,
-                                false,
-                                ACCESS_TOKEN
-                        )
-                );
-
         this.mockMvc.perform(
                         multipart("/api/v2/signup")
                                 .file("profileImage", null)

--- a/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
+++ b/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
@@ -38,13 +38,13 @@ public class MemberFixture {
             ".wrong_member#",
             "공백이 아닌 열다섯자 이내인 회원의 이름",
             """
-                    1
-                    2
-                    3
-                    3줄 이내
-                    """,
+            1
+            2
+            3
+            3줄 이내
+            """,
             "aaa@pochak.com",
-            PROFILE_IMAGE,
+            null,
             "REFRESH_TOKEN",
             "SOCIAL_ID",
             SocialType.APPLE,

--- a/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
+++ b/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
@@ -9,7 +9,7 @@ public class MemberFixture {
 
     public static final Member STATIC_MEMBER1 = new Member(
             1L,
-            "static-member1",
+            "static_member1",
             "1번 회원의 이름",
             "한 줄 소개",
             "aaa@pochak.com",
@@ -22,9 +22,27 @@ public class MemberFixture {
 
     public static final Member STATIC_MEMBER2 = new Member(
             2L,
-            "static-member2",
+            "static_member2",
             "2번 회원의 이름",
             "한 줄 소개",
+            "aaa@pochak.com",
+            PROFILE_IMAGE,
+            "REFRESH_TOKEN",
+            "SOCIAL_ID",
+            SocialType.APPLE,
+            "SOCIAL_REFRESH_TOKEN"
+    );
+
+    public static final Member WRONG_MEMBER = new Member(
+            3L,
+            ".wrong_member#",
+            "공백이 아닌 열다섯자 이내인 회원의 이름",
+            """
+                    1
+                    2
+                    3
+                    3줄 이내
+                    """,
             "aaa@pochak.com",
             PROFILE_IMAGE,
             "REFRESH_TOKEN",


### PR DESCRIPTION
## 📒 개요

한 줄 소개 : 최대 50자/최대 3줄
핸들 : 대문자, 소문자, 숫자, _(언더바), .(마침표) 만 허용 / 최대 15자
이름: 최대 10 - 15자 (공백만 있는 " " 와 같은 경우는 불가능)

## 📍 Issue 번호

- #108 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] 한 줄 소개
- [x] 핸들
- [x] 이름
- [x] 이메일

## 🧰 추가 논의사항

- 프로필 이미지 nullable하게 할까요?
- Fixture에 WRONG_MEMBER는 컨트롤러 테스트하려고 추가해뒀습니다
- 테스트는 잘 됩니다
- 핸들에 맨 첫글자에 언더바나 마침표가 와도 괜찮을까요?
