### PR TITLE
[feat/#134-memories-timeline] 추억페이지 response DTO 타임라인 추가

### DIFF
--- a/src/main/java/com/apps/pochak/global/util/TimeUtil.java
+++ b/src/main/java/com/apps/pochak/global/util/TimeUtil.java
@@ -1,0 +1,10 @@
+package com.apps.pochak.global.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class TimeUtil {
+    public static LocalDateTime atMidnight(int year) {
+        return LocalDate.now().minusYears(year).atStartOfDay();
+    }
+}

--- a/src/main/java/com/apps/pochak/memories/domain/MemoriesType.java
+++ b/src/main/java/com/apps/pochak/memories/domain/MemoriesType.java
@@ -1,0 +1,10 @@
+package com.apps.pochak.memories.domain;
+
+public enum MemoriesType {
+    Followed,
+    Follow,
+    FirstPochaked,
+    FirstPochak,
+    FirstBonded,
+    LatestPost
+}

--- a/src/main/java/com/apps/pochak/memories/domain/MemoriesType.java
+++ b/src/main/java/com/apps/pochak/memories/domain/MemoriesType.java
@@ -6,5 +6,6 @@ public enum MemoriesType {
     FirstPochaked,
     FirstPochak,
     FirstBonded,
-    LatestPost
+    LatestPost,
+    Post1YearAgo
 }

--- a/src/main/java/com/apps/pochak/memories/dto/MemoriesElement.java
+++ b/src/main/java/com/apps/pochak/memories/dto/MemoriesElement.java
@@ -1,5 +1,6 @@
 package com.apps.pochak.memories.dto;
 
+import com.apps.pochak.memories.domain.MemoriesType;
 import com.apps.pochak.tag.domain.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/apps/pochak/memories/service/MemoriesService.java
+++ b/src/main/java/com/apps/pochak/memories/service/MemoriesService.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.apps.pochak.global.util.PageUtil.getFirstContentFromPage;
+import static com.apps.pochak.global.util.TimeUtil.atMidnight;
 
 @Service
 @Transactional(readOnly = true)
@@ -47,6 +48,8 @@ public class MemoriesService {
         final Page<Tag> taggedWithDesc = tagRepository.findTaggedWith(loginMember, member, PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "post.allowedDate")));
         final Page<Tag> tagOrTagged = tagRepository.findLatestTagged(loginMember, member, PageRequest.of(0, 1));
 
+        final Page<Tag> tag1YearAgo = tagRepository.findTaggedByDate(loginMember, member, atMidnight(1), atMidnight(1).plusDays(1), PageRequest.of(0, 1));
+
         final Tag latestTaggedWith = getFirstContentFromPage(taggedWithDesc);
         final Tag latestTagOrTagged = getFirstContentFromPage(tagOrTagged);
 
@@ -55,6 +58,7 @@ public class MemoriesService {
         tags.put(MemoriesType.FirstPochak, getFirstContentFromPage(tag));
         tags.put(MemoriesType.FirstBonded, getFirstContentFromPage(taggedWithAsc));
         tags.put(MemoriesType.LatestPost, findLatestTag(latestTaggedWith, latestTagOrTagged));
+        tags.put(MemoriesType.Post1YearAgo, getFirstContentFromPage(tag1YearAgo));
 
         return MemoriesPreviewResponse.of()
                 .loginMember(loginMember)

--- a/src/main/java/com/apps/pochak/memories/service/MemoriesService.java
+++ b/src/main/java/com/apps/pochak/memories/service/MemoriesService.java
@@ -5,6 +5,7 @@ import com.apps.pochak.follow.domain.Follow;
 import com.apps.pochak.follow.domain.repository.FollowRepository;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
+import com.apps.pochak.memories.domain.MemoriesType;
 import com.apps.pochak.memories.dto.response.MemoriesPostResponse;
 import com.apps.pochak.memories.dto.response.MemoriesPreviewResponse;
 import com.apps.pochak.post.domain.repository.PostRepository;
@@ -17,6 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.apps.pochak.global.util.PageUtil.getFirstContentFromPage;
 
@@ -43,13 +47,14 @@ public class MemoriesService {
         final Page<Tag> taggedWithDesc = tagRepository.findTaggedWith(loginMember, member, PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "post.allowedDate")));
         final Page<Tag> tagOrTagged = tagRepository.findLatestTagged(loginMember, member, PageRequest.of(0, 1));
 
-        final Tag firstTagged = getFirstContentFromPage(tagged);
-        final Tag firstTag = getFirstContentFromPage(tag);
-        final Tag firstTaggedWith = getFirstContentFromPage(taggedWithAsc);
         final Tag latestTaggedWith = getFirstContentFromPage(taggedWithDesc);
         final Tag latestTagOrTagged = getFirstContentFromPage(tagOrTagged);
 
-        final Tag latestTag = findLatestTag(latestTaggedWith, latestTagOrTagged);
+        final Map<MemoriesType, Tag> tags = new HashMap<>();
+        tags.put(MemoriesType.FirstPochaked, getFirstContentFromPage(tagged));
+        tags.put(MemoriesType.FirstPochak, getFirstContentFromPage(tag));
+        tags.put(MemoriesType.FirstBonded, getFirstContentFromPage(taggedWithAsc));
+        tags.put(MemoriesType.LatestPost, findLatestTag(latestTaggedWith, latestTagOrTagged));
 
         return MemoriesPreviewResponse.of()
                 .loginMember(loginMember)
@@ -59,10 +64,7 @@ public class MemoriesService {
                 .countTag(countTag)
                 .countTaggedWith(countTaggedWith)
                 .countTagged(countTagged)
-                .firstTagged(firstTagged)
-                .firstTag(firstTag)
-                .firstTaggedWith(firstTaggedWith)
-                .latestTag(latestTag)
+                .tags(tags)
                 .build();
     }
 

--- a/src/main/java/com/apps/pochak/tag/domain/repository/TagRepository.java
+++ b/src/main/java/com/apps/pochak/tag/domain/repository/TagRepository.java
@@ -12,6 +12,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -104,4 +106,17 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     and (t1.member = :loginMember and t2.member = :member)
     """)
     Long countByMember(@Param("loginMember") Member loginMember, @Param("member")Member member);
+
+    @Query("""
+    select t from Tag t
+    join fetch t.member m
+    join fetch t.post p
+    where p.postStatus = 'PUBLIC'
+    and p.status = 'ACTIVE'
+    and ((m = :member and p.owner = :loginMember)
+    or (m = :loginMember and p.owner = :member))
+    and (p.allowedDate >= :startDay and p.allowedDate < :endDay)
+    order by p.allowedDate desc
+    """)
+    Page<Tag>  findTaggedByDate(@Param("loginMember")Member loginMember, @Param("member")Member member, LocalDateTime startDay, LocalDateTime endDay, Pageable pageable);
 }

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -71,6 +71,7 @@ class MemoriesControllerTest extends ControllerTest {
         tags.put(MemoriesType.FirstPochak, APPROVED_TAG);
         tags.put(MemoriesType.FirstBonded, APPROVED_TAG);
         tags.put(MemoriesType.LatestPost, APPROVED_TAG);
+        tags.put(MemoriesType.Post1YearAgo, APPROVED_TAG);
     }
 
     @Test
@@ -137,6 +138,9 @@ class MemoriesControllerTest extends ControllerTest {
                                         fieldWithPath("result.memories.LatestPost.postId").type(NUMBER).description("최근 포착 순간의 게시물 아이디"),
                                         fieldWithPath("result.memories.LatestPost.postImage").type(STRING).description("최근 포착 순간의 게시물 이미지"),
                                         fieldWithPath("result.memories.LatestPost.postDate").type(STRING).description("최근 포착 순간의 게시물 날짜"),
+                                        fieldWithPath("result.memories.Post1YearAgo.postId").type(NUMBER).description("1년전 포착 순간의 게시물 아이디"),
+                                        fieldWithPath("result.memories.Post1YearAgo.postImage").type(STRING).description("1년전 포착 순간의 게시물 이미지"),
+                                        fieldWithPath("result.memories.Post1YearAgo.postDate").type(STRING).description("1년전 포착 순간의 게시물 날짜"),
                                         fieldWithPath("result.timeLine").type(OBJECT).description("추억 타임라인"),
                                         fieldWithPath("result.timeLine.*").type(STRING).description("추억 타임라인 날짜")
                                 )

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -4,6 +4,7 @@ import com.apps.pochak.auth.domain.Accessor;
 import com.apps.pochak.follow.domain.Follow;
 import com.apps.pochak.global.ControllerTest;
 import com.apps.pochak.member.domain.Member;
+import com.apps.pochak.memories.domain.MemoriesType;
 import com.apps.pochak.memories.dto.response.MemoriesPostResponse;
 import com.apps.pochak.memories.dto.response.MemoriesPreviewResponse;
 import com.apps.pochak.memories.service.MemoriesService;
@@ -17,7 +18,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.apps.pochak.follow.fixture.FollowFixture.STATIC_RECEIVE_FOLLOW;
 import static com.apps.pochak.follow.fixture.FollowFixture.STATIC_SEND_FOLLOW;
@@ -49,6 +52,7 @@ class MemoriesControllerTest extends ControllerTest {
     private static final Follow SEND_FOLLOW = STATIC_SEND_FOLLOW;
     private static final Follow RECEIVE_FOLLOW = STATIC_RECEIVE_FOLLOW;
     private static final Tag APPROVED_TAG = STATIC_APPROVED_TAG;
+    private final Map<MemoriesType, Tag> tags = new HashMap<>();
 
     @MockBean
     MemoriesService memoriesService;
@@ -62,6 +66,11 @@ class MemoriesControllerTest extends ControllerTest {
 
         SEND_FOLLOW.updateLastModifiedDate();
         RECEIVE_FOLLOW.updateLastModifiedDate();
+
+        tags.put(MemoriesType.FirstPochaked, APPROVED_TAG);
+        tags.put(MemoriesType.FirstPochak, APPROVED_TAG);
+        tags.put(MemoriesType.FirstBonded, APPROVED_TAG);
+        tags.put(MemoriesType.LatestPost, APPROVED_TAG);
     }
 
     @Test
@@ -76,10 +85,7 @@ class MemoriesControllerTest extends ControllerTest {
                         .countTag(20L)
                         .countTaggedWith(15L)
                         .countTagged(30L)
-                        .firstTagged(APPROVED_TAG)
-                        .firstTag(APPROVED_TAG)
-                        .firstTaggedWith(APPROVED_TAG)
-                        .latestTag(APPROVED_TAG)
+                        .tags(tags)
                         .build()
                 );
 
@@ -114,22 +120,25 @@ class MemoriesControllerTest extends ControllerTest {
                                         fieldWithPath("result.pochakCount").type(NUMBER).description("POCHAK 게시물 수"),
                                         fieldWithPath("result.bondedCount").type(NUMBER).description("BONDED 게시물 수"),
                                         fieldWithPath("result.pochakedCount").type(NUMBER).description("POCHAKED 게시물 수"),
-                                        fieldWithPath("result.firstPochaked").type(OBJECT).description("처음 포착된 순간"),
-                                        fieldWithPath("result.firstPochak").type(OBJECT).description("처음 포착한 순간"),
-                                        fieldWithPath("result.firstBonded").type(OBJECT).description("처음 함께 포착된 순간"),
-                                        fieldWithPath("result.latestPost").type(OBJECT).description("최근 포착 순간"),
-                                        fieldWithPath("result.firstPochaked.postId").type(NUMBER).description("처음 포착된 순간의 게시물 아이디"),
-                                        fieldWithPath("result.firstPochaked.postImage").type(STRING).description("처음 포착된 순간의 게시물 이미지"),
-                                        fieldWithPath("result.firstPochaked.postDate").type(STRING).description("처음 포착된 순간의 게시물 날짜"),
-                                        fieldWithPath("result.firstPochak.postId").type(NUMBER).description("처음 포착한 순간의 게시물 아이디"),
-                                        fieldWithPath("result.firstPochak.postImage").type(STRING).description("처음 포착한 순간의 게시물 이미지"),
-                                        fieldWithPath("result.firstPochak.postDate").type(STRING).description("처음 포착한 순간의 게시물 날짜"),
-                                        fieldWithPath("result.firstBonded.postId").type(NUMBER).description("처음 함께 포착된 순간의 게시물 아이디"),
-                                        fieldWithPath("result.firstBonded.postImage").type(STRING).description("처음 함께 포착된 순간의 게시물 이미지"),
-                                        fieldWithPath("result.firstBonded.postDate").type(STRING).description("처음 함께 포착된 순간의 게시물 날짜"),
-                                        fieldWithPath("result.latestPost.postId").type(NUMBER).description("최근 포착 순간의 게시물 아이디"),
-                                        fieldWithPath("result.latestPost.postImage").type(STRING).description("최근 포착 순간의 게시물 이미지"),
-                                        fieldWithPath("result.latestPost.postDate").type(STRING).description("최근 포착 순간의 게시물 날짜")
+                                        fieldWithPath("result.memories").type(OBJECT).description("추억 갤러리 프리뷰"),
+                                        fieldWithPath("result.memories.FirstPochaked").type(OBJECT).description("처음 포착된 순간"),
+                                        fieldWithPath("result.memories.FirstPochak").type(OBJECT).description("처음 포착한 순간"),
+                                        fieldWithPath("result.memories.FirstBonded").type(OBJECT).description("처음 함께 포착된 순간"),
+                                        fieldWithPath("result.memories.LatestPost").type(OBJECT).description("최근 포착 순간"),
+                                        fieldWithPath("result.memories.FirstPochaked.postId").type(NUMBER).description("처음 포착된 순간의 게시물 아이디"),
+                                        fieldWithPath("result.memories.FirstPochaked.postImage").type(STRING).description("처음 포착된 순간의 게시물 이미지"),
+                                        fieldWithPath("result.memories.FirstPochaked.postDate").type(STRING).description("처음 포착된 순간의 게시물 날짜"),
+                                        fieldWithPath("result.memories.FirstPochak.postId").type(NUMBER).description("처음 포착한 순간의 게시물 아이디"),
+                                        fieldWithPath("result.memories.FirstPochak.postImage").type(STRING).description("처음 포착한 순간의 게시물 이미지"),
+                                        fieldWithPath("result.memories.FirstPochak.postDate").type(STRING).description("처음 포착한 순간의 게시물 날짜"),
+                                        fieldWithPath("result.memories.FirstBonded.postId").type(NUMBER).description("처음 함께 포착된 순간의 게시물 아이디"),
+                                        fieldWithPath("result.memories.FirstBonded.postImage").type(STRING).description("처음 함께 포착된 순간의 게시물 이미지"),
+                                        fieldWithPath("result.memories.FirstBonded.postDate").type(STRING).description("처음 함께 포착된 순간의 게시물 날짜"),
+                                        fieldWithPath("result.memories.LatestPost.postId").type(NUMBER).description("최근 포착 순간의 게시물 아이디"),
+                                        fieldWithPath("result.memories.LatestPost.postImage").type(STRING).description("최근 포착 순간의 게시물 이미지"),
+                                        fieldWithPath("result.memories.LatestPost.postDate").type(STRING).description("최근 포착 순간의 게시물 날짜"),
+                                        fieldWithPath("result.timeLine").type(OBJECT).description("추억 타임라인"),
+                                        fieldWithPath("result.timeLine.*").type(STRING).description("추억 타임라인 날짜")
                                 )
                         )
                 );

--- a/src/test/java/com/apps/pochak/tag/domain/repository/TagRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/tag/domain/repository/TagRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.apps.pochak.global.util.PageUtil.getFirstContentFromPage;
@@ -142,5 +143,21 @@ class TagRepositoryTest {
         Page<Tag> tag = tagRepository.findTagByOwnerAndMember(owner, member, PageRequest.of(0, 1));
         Long count = tagRepository.countByPost_PostStatusAndPost_OwnerAndMember(PostStatus.PUBLIC, owner, member);
         assertThat(count).isEqualTo(tag.getTotalElements());
+    }
+
+    @Test
+    @DisplayName("[추억 페이지] 1년 전, 내가 태그하거나 태그된 게시물을 조회한다.")
+    void findTagByLocalDate() {
+        Member owner = memberRepository.findByHandleWithoutLogin("owner");
+        Member member = memberRepository.findByHandleWithoutLogin("tagged_member1");
+
+        Page<Tag> tag1YearAgo = tagRepository.findTaggedByDate(owner, member, LocalDate.now().atStartOfDay(),
+                LocalDate.now().atStartOfDay().plusDays(1), PageRequest.of(0, 1));
+        System.out.println(tag1YearAgo.getContent().get(0).getPost().getAllowedDate());
+
+        assertThat(tag1YearAgo.getContent().get(0).getPost().getAllowedDate())
+                .isAfter(LocalDate.now().atStartOfDay())
+                .isBefore(LocalDate.now().atStartOfDay().plusDays(1));
+        assertThat(tag1YearAgo).isNotNull();
     }
 }


### PR DESCRIPTION
## 📒 개요

- response DTO의 firstPochak, firstPochaked, firstBonded, latestPost를 확장성을 고려하여 Map<>으로 변경하였습니다
- 타임라인 Map을 추가하였습니다. 날짜순 정렬을 위해 TreeMap으로 설정하였습니다. 

## 📍 Issue 번호

- #134 

## 🛠️ 작업사항

- [x] MemoriesPreviewResponse>Map<MemoriesType, MemoriesElement> memories
- [x] MemoriesPreviewResponse> Map<LocalDateTime, MemoriesType> timeLine
- [x] controller test

## 🧰 추가 논의사항

- 타임라인 Map 구현사항 중, 저장된 날짜가 초단위까지 같은 경우 (key가 같은 경우) value가 덮어씌워질 수 있다는 문제가 걱정되면 고치는 게 맞을 것 같습니다. 0.00001초까지 똑같은 경우가 있을까?.. 싶어서 저는 날짜를 키값으로 설정하였습니다! 그래야 정렬이 간단해서요. 