### PR TITLE
[fix/#121-fcm-token-specify] FCM Token 지정 에러

### DIFF
--- a/src/main/java/com/apps/pochak/fcm/service/FCMService.java
+++ b/src/main/java/com/apps/pochak/fcm/service/FCMService.java
@@ -6,7 +6,6 @@ import com.apps.pochak.fcm.dto.FCMToken;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
 import jakarta.transaction.Transactional;
@@ -40,11 +39,8 @@ public class FCMService {
         try {
             Message message = makeMessage(alarm);
             firebaseMessaging.send(message);
-        } catch (FirebaseMessagingException e) {
-            // TODO: 로깅 수정
-            log.error(
-                    String.format("[FCM Error] Token: %s \n Msg: %s", alarm.getReceiver().getFcmToken(), e.getMessage())
-            );
+        } catch (Exception e) {
+            log.error("[FCM] token = {}, msg = {}", alarm.getReceiver().getFcmToken(), e.getMessage());
         }
     }
 
@@ -53,8 +49,8 @@ public class FCMService {
         try {
             MulticastMessage multicastMessage = makeMessages(alarmList);
             firebaseMessaging.sendEachForMulticast(multicastMessage);
-        } catch (FirebaseMessagingException e) {
-            log.error(String.format("[FCM Error]\n Msg: %s", e.getMessage()));
+        } catch (Exception e) {
+            log.error("[FCM] msg = {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
## 📒 개요

token specify가 되지 않으면 에러가 발생하여 Exception 캐칭하고, 로그 남기도록 수정하였습니다.
- Exception을 터뜨려 해당 트랜잭션을 롤백할 정도의 에러는 아니라고 생각하여 로그만 남김.

## 📍 Issue 번호

- #121 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] 에러 핸들링
- [x] 로깅
