### PR TITLE
[Fix/#6-logging] response가 String인 경우 CastException 발생 처리

### DIFF
--- a/src/main/java/com/apps/pochak/global/aspect/LogAspect.java
+++ b/src/main/java/com/apps/pochak/global/aspect/LogAspect.java
@@ -22,7 +22,7 @@ import static com.apps.pochak.global.util.RequestInfo.createRequestFullPath;
 @Slf4j
 public class LogAspect {
 
-    @Around("execution(* com.apps.pochak..*Controller.*(..))")
+    @Around("execution(* com.apps.pochak..*Controller.*(..)) && !execution(* com.apps.pochak..HomeController.*(..))")
     public Object apiLogging(ProceedingJoinPoint joinPoint) throws Throwable {
         long startAt = System.currentTimeMillis();
 


### PR DESCRIPTION
## 📒 개요

유일하게 String을 반환하는 HomeController를 aop 적용 범위에서 제외하였다 ...

## 📍 Issue 번호

- #6
