### PR TITLE
[fix/#47-refresh-token-npe] 토큰 NPE 핸들링

### DIFF
--- a/src/main/java/com/apps/pochak/login/util/LoginArgumentResolver.java
+++ b/src/main/java/com/apps/pochak/login/util/LoginArgumentResolver.java
@@ -35,7 +35,7 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
         try {
             final Long memberId = Long.valueOf(principal.toString());
             return Accessor.member(memberId);
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | NullPointerException e) {
             throw new AuthenticationException(_INVALID_AUTHORITY);
         }
     }


### PR DESCRIPTION
## 📒 개요

access token 자리에 refresh token을 넣으면 npe가 발생했는데,
접근 권한 에러핸들링 추가하여 해결하였습니다 ㅎㅎ; 생각보다 간단

## 📍 Issue 번호

- #47 

## 🛠️ 작업사항

- [x] 에러 핸들링 조건 추가
