### PR TITLE
[Feat/#129-getPostDetail-Datetime] 게시물 상세 조회 responseDto에 게시 날짜 및 시간 포함하기

### DIFF
--- a/src/main/java/com/apps/pochak/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/apps/pochak/post/dto/response/PostDetailResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,6 +25,7 @@ public class PostDetailResponse {
     private List<TagElement> tagList;
     private Boolean isFollow;
     private String postImage;
+    private LocalDateTime allowedDate;
     private Boolean isLike;
     private int likeCount;
     private String caption;
@@ -47,6 +49,7 @@ public class PostDetailResponse {
         ).collect(Collectors.toList());
         this.isFollow = isFollow;
         this.postImage = post.getPostImage();
+        this.allowedDate = post.getAllowedDate();
         this.isLike = isLike;
         this.likeCount = likeCount;
         this.caption = post.getCaption();

--- a/src/test/java/com/apps/pochak/post/controller/PostControllerTest.java
+++ b/src/test/java/com/apps/pochak/post/controller/PostControllerTest.java
@@ -263,6 +263,7 @@ class PostControllerTest extends ControllerTest {
                                                                 ": 만약 로그인한 유저가 게시자라면 null로 전달됨."
                                                 ),
                                         fieldWithPath("result.postImage").type(STRING).description("게시물 이미지 URL"),
+                                        fieldWithPath("result.allowedDate").type(STRING).description("게시 날짜 및 시간"),
                                         fieldWithPath("result.isLike").type(BOOLEAN)
                                                 .description(
                                                         "현재 로그인한 유저가 해당 게시물의 좋아요를 눌렀는지 여부"


### PR DESCRIPTION
## 📒 개요

게시물 상세 조회 responseDto에 게시 날짜 및 시간 포함하기

## 📍 Issue 번호

- #129 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] dto 수정
- [x] 컨트롤러 테스트
