### PR TITLE
[Feat/#122-savePost-image-delete] 게시물 업로드 에러 발생시 업로드된 이미지 삭제하기

### DIFF
--- a/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
+++ b/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
@@ -15,8 +15,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
-import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.IO_EXCEPTION;
-import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.NULL_FILE;
+import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -56,7 +55,11 @@ public class CloudStorageService {
         if (blob == null) return;
 
         BlobId idWithGeneration = blob.getBlobId();
-        storage.delete(idWithGeneration);
+        try {
+            storage.delete(idWithGeneration);
+        } catch (Exception e) {
+            throw new GeneralException(DELETE_FILE_ERROR);
+        }
     }
 
     private String getObjectNameFromUrl(final String fileUrl) {


### PR DESCRIPTION
## 📒 개요

- 업로드 에러 발생을 잡기 위해 try-catch를 추가하였습니다
- 예외처리시 @Transactional의 롤백 처리가 안될 것이기 때문에 잡은 예외를 다시 던져주었습니다

## 📍 Issue 번호

- #122 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] try-catch로 처리해보았습니다 -> 더 좋은 방법을 알고계시면 말씀해주세요
- [x] cloudStorageService에서 image delete시 예외처리 작성해주었습니다 -> 필요없다면 말씀해주세요 ..

## 🧰 추가 논의사항

- `validateInvalidMemberTag`에서는 image delete를 안해줘도 될 것 같다는 생각이 듭니다?!
- 알아보다가 Transactional이 runtimeException(unchecked) 발생시에만 롤백을 해준다고 합니다 `@Transactional(rollbackFor=Exception.class)`을 쓰지 않은 이유가 있나요?
