### PR TITLE
[Fix/#151-memories-NPE] 추억페이지 조회시 null Tag 조회 막기, 타임라인 postOwner 추가 전달하기

### DIFF
--- a/src/main/java/com/apps/pochak/memories/dto/TimeLineElement.java
+++ b/src/main/java/com/apps/pochak/memories/dto/TimeLineElement.java
@@ -1,0 +1,22 @@
+package com.apps.pochak.memories.dto;
+
+import com.apps.pochak.memories.domain.MemoriesType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeLineElement {
+    private MemoriesType memoriesType;
+    private String postOwner;
+
+    public static TimeLineElement from(final MemoriesType memoriesType, final String postOwner) {
+        return new TimeLineElement(memoriesType, postOwner);
+    }
+
+    public static TimeLineElement from(final MemoriesType memoriesType) {
+        return new TimeLineElement(memoriesType, null);
+    }
+}

--- a/src/main/java/com/apps/pochak/memories/dto/TimeLineElement.java
+++ b/src/main/java/com/apps/pochak/memories/dto/TimeLineElement.java
@@ -1,5 +1,6 @@
 package com.apps.pochak.memories.dto;
 
+import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.memories.domain.MemoriesType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,13 +11,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TimeLineElement {
     private MemoriesType memoriesType;
-    private String postOwner;
+    private String postOwnerHandle;
 
-    public static TimeLineElement from(final MemoriesType memoriesType, final String postOwner) {
-        return new TimeLineElement(memoriesType, postOwner);
+    public static TimeLineElement of(final MemoriesType memoriesType, final Member postOwner) {
+        return new TimeLineElement(memoriesType, postOwner.getHandle());
     }
 
-    public static TimeLineElement from(final MemoriesType memoriesType) {
+    public static TimeLineElement of(final MemoriesType memoriesType) {
         return new TimeLineElement(memoriesType, null);
     }
 }

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -4,6 +4,7 @@ import com.apps.pochak.follow.domain.Follow;
 import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.memories.domain.MemoriesType;
 import com.apps.pochak.memories.dto.MemoriesElement;
+import com.apps.pochak.memories.dto.TimeLineElement;
 import com.apps.pochak.tag.domain.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,7 +30,7 @@ public class MemoriesPreviewResponse {
     private Long bondedCount;
     private Long pochakedCount;
     private Map<MemoriesType, MemoriesElement> memories = new HashMap<>();
-    private Map<LocalDateTime, MemoriesType> timeLine = new TreeMap<>(Comparator.reverseOrder());
+    private Map<LocalDateTime, TimeLineElement> timeLine = new TreeMap<>(Comparator.reverseOrder());
 
     @Builder(builderMethodName = "of")
     public MemoriesPreviewResponse(
@@ -46,9 +47,9 @@ public class MemoriesPreviewResponse {
         this.loginMemberProfileImage = loginMember.getProfileImage();
         this.memberProfileImage = member.getProfileImage();
         this.followDate = follow.getLastModifiedDate();
-        this.timeLine.put(this.followDate, MemoriesType.Follow);
+        this.timeLine.put(this.followDate, TimeLineElement.from(MemoriesType.Follow, null));
         this.followedDate = followed.getLastModifiedDate();
-        this.timeLine.put(this.followedDate, MemoriesType.Followed);
+        this.timeLine.put(this.followedDate, TimeLineElement.from(MemoriesType.Follow, null));
         this.followDay = findFollowDay(followDate, followedDate);
         this.pochakCount = countTag;
         this.bondedCount = countTaggedWith;
@@ -56,7 +57,8 @@ public class MemoriesPreviewResponse {
         for (MemoriesType memoriesType : tags.keySet()) {
             this.memories.put(memoriesType, MemoriesElement.from(tags.get(memoriesType)));
             if (tags.get(memoriesType) != null) {
-                this.timeLine.put(tags.get(memoriesType).getPost().getAllowedDate(), memoriesType);
+                this.timeLine.put(tags.get(memoriesType).getPost().getAllowedDate(),
+                        TimeLineElement.from(MemoriesType.Follow, tags.get(memoriesType).getPost().getOwner().getHandle()));
             }
         }
     }

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -55,7 +55,9 @@ public class MemoriesPreviewResponse {
         this.pochakedCount = countTagged;
         for (MemoriesType memoriesType : tags.keySet()) {
             this.memories.put(memoriesType, MemoriesElement.from(tags.get(memoriesType)));
-            this.timeLine.put(tags.get(memoriesType).getPost().getAllowedDate(), memoriesType);
+            if (tags.get(memoriesType) != null) {
+                this.timeLine.put(tags.get(memoriesType).getPost().getAllowedDate(), memoriesType);
+            }
         }
     }
 

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -49,7 +49,7 @@ public class MemoriesPreviewResponse {
         this.followDate = follow.getLastModifiedDate();
         this.timeLine.put(this.followDate, TimeLineElement.from(MemoriesType.Follow, null));
         this.followedDate = followed.getLastModifiedDate();
-        this.timeLine.put(this.followedDate, TimeLineElement.from(MemoriesType.Follow, null));
+        this.timeLine.put(this.followedDate, TimeLineElement.from(MemoriesType.Followed, null));
         this.followDay = findFollowDay(followDate, followedDate);
         this.pochakCount = countTag;
         this.bondedCount = countTaggedWith;

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -58,7 +58,7 @@ public class MemoriesPreviewResponse {
             this.memories.put(memoriesType, MemoriesElement.from(tags.get(memoriesType)));
             if (tags.get(memoriesType) != null) {
                 this.timeLine.put(tags.get(memoriesType).getPost().getAllowedDate(),
-                        TimeLineElement.from(MemoriesType.Follow, tags.get(memoriesType).getPost().getOwner().getHandle()));
+                        TimeLineElement.from(memoriesType, tags.get(memoriesType).getPost().getOwner().getHandle()));
             }
         }
     }

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -47,9 +47,9 @@ public class MemoriesPreviewResponse {
         this.loginMemberProfileImage = loginMember.getProfileImage();
         this.memberProfileImage = member.getProfileImage();
         this.followDate = follow.getLastModifiedDate();
-        this.timeLine.put(this.followDate, TimeLineElement.from(MemoriesType.Follow, null));
+        this.timeLine.put(this.followDate, TimeLineElement.of(MemoriesType.Follow, null));
         this.followedDate = followed.getLastModifiedDate();
-        this.timeLine.put(this.followedDate, TimeLineElement.from(MemoriesType.Followed, null));
+        this.timeLine.put(this.followedDate, TimeLineElement.of(MemoriesType.Followed, null));
         this.followDay = findFollowDay(followDate, followedDate);
         this.pochakCount = countTag;
         this.bondedCount = countTaggedWith;
@@ -58,7 +58,7 @@ public class MemoriesPreviewResponse {
             this.memories.put(memoriesType, MemoriesElement.from(tags.get(memoriesType)));
             if (tags.get(memoriesType) != null) {
                 this.timeLine.put(tags.get(memoriesType).getPost().getAllowedDate(),
-                        TimeLineElement.from(memoriesType, tags.get(memoriesType).getPost().getOwner().getHandle()));
+                        TimeLineElement.of(memoriesType, tags.get(memoriesType).getPost().getOwner()));
             }
         }
     }

--- a/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
+++ b/src/main/java/com/apps/pochak/memories/dto/response/MemoriesPreviewResponse.java
@@ -47,9 +47,9 @@ public class MemoriesPreviewResponse {
         this.loginMemberProfileImage = loginMember.getProfileImage();
         this.memberProfileImage = member.getProfileImage();
         this.followDate = follow.getLastModifiedDate();
-        this.timeLine.put(this.followDate, TimeLineElement.of(MemoriesType.Follow, null));
+        this.timeLine.put(this.followDate, TimeLineElement.of(MemoriesType.Follow));
         this.followedDate = followed.getLastModifiedDate();
-        this.timeLine.put(this.followedDate, TimeLineElement.of(MemoriesType.Followed, null));
+        this.timeLine.put(this.followedDate, TimeLineElement.of(MemoriesType.Followed));
         this.followDay = findFollowDay(followDate, followedDate);
         this.pochakCount = countTag;
         this.bondedCount = countTaggedWith;

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -142,7 +142,9 @@ class MemoriesControllerTest extends ControllerTest {
                                         fieldWithPath("result.memories.Post1YearAgo.postImage").type(STRING).description("1년전 포착 순간의 게시물 이미지"),
                                         fieldWithPath("result.memories.Post1YearAgo.postDate").type(STRING).description("1년전 포착 순간의 게시물 날짜"),
                                         fieldWithPath("result.timeLine").type(OBJECT).description("추억 타임라인"),
-                                        fieldWithPath("result.timeLine.*").type(STRING).description("추억 타임라인 날짜")
+                                        fieldWithPath("result.timeLine.*").type(OBJECT).description("추억 타임라인 날짜"),
+                                        fieldWithPath("result.timeLine.*.memoriesType").type(STRING).description("추억 타임라인 타입"),
+                                        fieldWithPath("result.timeLine.*.postOwner").type(STRING).description("추억 타임라인 게시글 작성자 아이디").optional()
                                 )
                         )
                 );

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -144,7 +144,7 @@ class MemoriesControllerTest extends ControllerTest {
                                         fieldWithPath("result.timeLine").type(OBJECT).description("추억 타임라인"),
                                         fieldWithPath("result.timeLine.*").type(OBJECT).description("추억 타임라인 날짜"),
                                         fieldWithPath("result.timeLine.*.memoriesType").type(STRING).description("추억 타임라인 타입"),
-                                        fieldWithPath("result.timeLine.*.postOwner").type(STRING).description("추억 타임라인 게시글 작성자 아이디").optional()
+                                        fieldWithPath("result.timeLine.*.postOwnerHandle").type(STRING).description("추억 타임라인 게시글 작성자 아이디").optional()
                                 )
                         )
                 );


### PR DESCRIPTION
## 📒 개요

Map value가 null인 것을 고려하지 못하고 조건 처리를 해주지 않았었다..
함께 태그된 게시물 조회시 timeLine에 필요한 게시물 작성자 정보를 추가해주었습니다

## 📍 Issue 번호

- #151 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] null값은 timeline에 넣지 않는다
- [x] 타임라인 postOwner 추가 전달하기 - TimeLineElement 새로 만들었습니다
- [x] controllerTest