### PR TITLE
[feat/#146-delete-post-image] 게시물 이미지 삭제 스케줄러

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ dependencyManagement {
 }
 
 test {
+    exclude '**/PostImageDeletionSchedulerTest.class'
     useJUnitPlatform()
     outputs.dir snippetsDir
 }

--- a/src/main/java/com/apps/pochak/global/config/ClockConfig.java
+++ b/src/main/java/com/apps/pochak/global/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.apps.pochak.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
+++ b/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
@@ -80,4 +80,10 @@ public class CloudStorageService {
         String encodedFileName = fileUrl.substring(fileUrl.indexOf(splitStr) + splitStr.length());
         return URLDecoder.decode(encodedFileName, StandardCharsets.UTF_8);
     }
+
+    public boolean isObjectDeleted(final String fileUrl) {
+        String objectName = getObjectNameFromUrl(fileUrl);
+        Blob blob = storage.get(bucketName, objectName);
+        return blob == null;
+    }
 }

--- a/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
+++ b/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
@@ -13,6 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.IO_EXCEPTION;
@@ -57,6 +59,20 @@ public class CloudStorageService {
 
         BlobId idWithGeneration = blob.getBlobId();
         storage.delete(idWithGeneration);
+    }
+
+    public void delete(final List<String> fileUrlList) {
+        List<BlobId> blobIdList = fileUrlList.stream().map(
+                        url -> {
+                            String objectName = getObjectNameFromUrl(url);
+                            Blob blob = storage.get(bucketName, objectName);
+                            if (blob == null) return null;
+                            return blob.getBlobId();
+                        }
+                ).filter(Objects::nonNull)
+                .toList();
+
+        storage.delete(blobIdList);
     }
 
     private String getObjectNameFromUrl(final String fileUrl) {

--- a/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
+++ b/src/main/java/com/apps/pochak/global/image/CloudStorageService.java
@@ -72,18 +72,33 @@ public class CloudStorageService {
                 ).filter(Objects::nonNull)
                 .toList();
 
-        storage.delete(blobIdList);
-    }
-
-    private String getObjectNameFromUrl(final String fileUrl) {
-        String splitStr = bucketName + "/";
-        String encodedFileName = fileUrl.substring(fileUrl.indexOf(splitStr) + splitStr.length());
-        return URLDecoder.decode(encodedFileName, StandardCharsets.UTF_8);
+        if (!blobIdList.isEmpty())
+            storage.delete(blobIdList);
     }
 
     public boolean isObjectDeleted(final String fileUrl) {
         String objectName = getObjectNameFromUrl(fileUrl);
         Blob blob = storage.get(bucketName, objectName);
         return blob == null;
+    }
+
+    public boolean isObjectDeleted(final List<String> fileUrlList) {
+        List<BlobId> blobIdList = fileUrlList.stream().map(
+                        url -> {
+                            String objectName = getObjectNameFromUrl(url);
+                            Blob blob = storage.get(bucketName, objectName);
+                            if (blob == null) return null;
+                            return blob.getBlobId();
+                        }
+                ).filter(Objects::nonNull)
+                .toList();
+
+        return blobIdList.isEmpty();
+    }
+
+    private String getObjectNameFromUrl(final String fileUrl) {
+        String splitStr = bucketName + "/";
+        String encodedFileName = fileUrl.substring(fileUrl.indexOf(splitStr) + splitStr.length());
+        return URLDecoder.decode(encodedFileName, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/apps/pochak/post/domain/repository/PostRepository.java
@@ -79,7 +79,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
         select p from Post p
-        where p.lastModifiedDate < :expiredDate
+        where p.lastModifiedDate <= :expiredDate
         and p.status = 'DELETED'
         """)
     Page<Post> findAllByDeletedAtBefore(

--- a/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
+++ b/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
@@ -16,11 +16,12 @@ import java.time.LocalDateTime;
 public class PostImageDeletionScheduler {
     private final PostRepository postRepository;
     private final CloudStorageService storageService;
+    public static final int EXPIRE_PERIOD = 30;
     public static final int DEFAULT_DELETION_SIZE = 100;
 
     @Scheduled(cron = "0 0 0 * * ?")
     public void deleteExpiredAlarms() {
-        final LocalDateTime expirationDate = LocalDateTime.now().minusDays(30);
+        final LocalDateTime expirationDate = LocalDateTime.now().minusDays(EXPIRE_PERIOD);
         PageRequest pageRequest = PageRequest.of(0, DEFAULT_DELETION_SIZE);
         Page<Post> deletedPost;
         do {

--- a/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
+++ b/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
@@ -1,0 +1,35 @@
+package com.apps.pochak.post.service;
+
+import com.apps.pochak.global.image.CloudStorageService;
+import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.post.domain.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class PostImageDeletionScheduler {
+    private final PostRepository postRepository;
+    private final CloudStorageService storageService;
+    public static final int DEFAULT_DELETION_SIZE = 100;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void deleteExpiredAlarms() {
+        final LocalDateTime expirationDate = LocalDateTime.now().minusDays(30);
+        PageRequest pageRequest = PageRequest.of(0, DEFAULT_DELETION_SIZE);
+        Page<Post> deletedPost;
+        do {
+            deletedPost = postRepository.findAllByDeletedAtBefore(
+                    expirationDate,
+                    pageRequest
+            );
+            storageService.delete(deletedPost.stream().map(Post::getPostImage).toList());
+            pageRequest.next();
+        } while (deletedPost.hasNext());
+    }
+}

--- a/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
+++ b/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 @Component
@@ -16,12 +17,14 @@ import java.time.LocalDateTime;
 public class PostImageDeletionScheduler {
     private final PostRepository postRepository;
     private final CloudStorageService storageService;
+    private final Clock clock;
+
     public static final int EXPIRE_PERIOD = 30;
     public static final int DEFAULT_DELETION_SIZE = 100;
 
     @Scheduled(cron = "0 0 0 * * ?")
     public void deleteExpiredAlarms() {
-        final LocalDateTime expirationDate = LocalDateTime.now().minusDays(EXPIRE_PERIOD);
+        final LocalDateTime expirationDate = LocalDateTime.now(clock).minusDays(EXPIRE_PERIOD);
         PageRequest pageRequest = PageRequest.of(0, DEFAULT_DELETION_SIZE);
         Page<Post> deletedPost;
         do {

--- a/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
+++ b/src/main/java/com/apps/pochak/post/service/PostImageDeletionScheduler.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -28,12 +29,13 @@ public class PostImageDeletionScheduler {
         PageRequest pageRequest = PageRequest.of(0, DEFAULT_DELETION_SIZE);
         Page<Post> deletedPost;
         do {
+            List<Post> postList = postRepository.findAll();
             deletedPost = postRepository.findAllByDeletedAtBefore(
                     expirationDate,
                     pageRequest
             );
             storageService.delete(deletedPost.stream().map(Post::getPostImage).toList());
-            pageRequest.next();
+            pageRequest = pageRequest.next();
         } while (deletedPost.hasNext());
     }
 }

--- a/src/test/java/com/apps/pochak/post/service/PostImageDeletionSchedulerTest.java
+++ b/src/test/java/com/apps/pochak/post/service/PostImageDeletionSchedulerTest.java
@@ -1,0 +1,115 @@
+package com.apps.pochak.post.service;
+
+import com.apps.pochak.auth.domain.Accessor;
+import com.apps.pochak.global.image.CloudStorageService;
+import com.apps.pochak.member.domain.Member;
+import com.apps.pochak.member.domain.repository.MemberRepository;
+import com.apps.pochak.post.domain.Post;
+import com.apps.pochak.post.domain.repository.PostRepository;
+import com.apps.pochak.post.dto.request.PostUploadRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static com.apps.pochak.global.MockMultipartFileConverter.getMockMultipartFileOfPost;
+import static com.apps.pochak.member.fixture.MemberFixture.*;
+import static com.apps.pochak.post.service.PostImageDeletionScheduler.EXPIRE_PERIOD;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class PostImageDeletionSchedulerTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    CloudStorageService storageService;
+
+    private Member owner;
+    private Member taggedMember1;
+    private Member taggedMember2;
+
+    @BeforeEach
+    void setUp() {
+        owner = memberRepository.save(OWNER);
+        taggedMember1 = memberRepository.save(TAGGED_MEMBER1);
+        taggedMember2 = memberRepository.save(TAGGED_MEMBER2);
+    }
+
+    @DisplayName("삭제된 지 1달이 지난 게시물 이미지가 삭제된다.")
+    @Test
+    void deletePostImage() throws Exception {
+        // given
+        Post post = savePublicPost();
+        deletePost(post);
+
+        // when
+        LocalDateTime expiredDate = LocalDateTime.now().plusDays(EXPIRE_PERIOD)
+                .withHour(0)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0);
+
+        Clock clock = Mockito.mock(Clock.class);
+        Mockito.when(clock.instant())
+                .thenReturn(expiredDate
+                        .atZone(ZoneId.of("Asia/Seoul"))
+                        .toInstant()
+                );
+
+        Thread.sleep(5000);
+
+        // then
+        assertTrue(storageService.isObjectDeleted(post.getPostImage()));
+    }
+
+    @DisplayName("삭제된 지 1달이 지난 100개 이상의 게시물 이미지가 삭제된다.")
+    @Test
+    void deletePostImage_WithMoreThan100Posts() throws Exception {
+        // given
+
+        // when
+
+        // then
+    }
+
+    private Post savePublicPost() throws Exception {
+        PostUploadRequest request = new PostUploadRequest(
+                getMockMultipartFileOfPost(),
+                "test caption",
+                List.of(taggedMember1.getHandle(), taggedMember2.getHandle())
+        );
+
+        postService.savePost(
+                Accessor.member(owner.getId()),
+                request
+        );
+        Post post = postRepository.findAll().get(0);
+        post.makePublic();
+
+        return post;
+    }
+
+    private void deletePost(final Post post) {
+        postService.deletePost(
+                Accessor.member(owner.getId()),
+                post.getId()
+        );
+    }
+}

--- a/src/test/java/com/apps/pochak/post/service/PostImageDeletionSchedulerTest.java
+++ b/src/test/java/com/apps/pochak/post/service/PostImageDeletionSchedulerTest.java
@@ -7,12 +7,13 @@ import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.post.domain.repository.PostRepository;
 import com.apps.pochak.post.dto.request.PostUploadRequest;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
@@ -22,11 +23,13 @@ import java.util.List;
 
 import static com.apps.pochak.global.MockMultipartFileConverter.getMockMultipartFileOfPost;
 import static com.apps.pochak.member.fixture.MemberFixture.*;
+import static com.apps.pochak.post.service.PostImageDeletionScheduler.DEFAULT_DELETION_SIZE;
 import static com.apps.pochak.post.service.PostImageDeletionScheduler.EXPIRE_PERIOD;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @Transactional
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest
 class PostImageDeletionSchedulerTest {
 
     @Autowired
@@ -40,6 +43,15 @@ class PostImageDeletionSchedulerTest {
 
     @Autowired
     CloudStorageService storageService;
+
+    @Autowired
+    PostImageDeletionScheduler postImageDeletionScheduler;
+
+    @Autowired
+    EntityManager em;
+
+    @MockBean
+    Clock clock;
 
     private Member owner;
     private Member taggedMember1;
@@ -59,21 +71,16 @@ class PostImageDeletionSchedulerTest {
         Post post = savePublicPost();
         deletePost(post);
 
+        LocalDateTime expiredDate = LocalDateTime.now().plusDays(EXPIRE_PERIOD);
+        Clock fixedClock = Clock.fixed(
+                expiredDate.atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                ZoneId.of("Asia/Seoul")
+        );
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+
         // when
-        LocalDateTime expiredDate = LocalDateTime.now().plusDays(EXPIRE_PERIOD)
-                .withHour(0)
-                .withMinute(0)
-                .withSecond(0)
-                .withNano(0);
-
-        Clock clock = Mockito.mock(Clock.class);
-        Mockito.when(clock.instant())
-                .thenReturn(expiredDate
-                        .atZone(ZoneId.of("Asia/Seoul"))
-                        .toInstant()
-                );
-
-        Thread.sleep(5000);
+        postImageDeletionScheduler.deleteExpiredAlarms();
 
         // then
         assertTrue(storageService.isObjectDeleted(post.getPostImage()));
@@ -83,10 +90,26 @@ class PostImageDeletionSchedulerTest {
     @Test
     void deletePostImage_WithMoreThan100Posts() throws Exception {
         // given
+        for (int i = 0; i <= DEFAULT_DELETION_SIZE; i++) {
+            savePublicPost();
+        }
+        postRepository.deleteAll();
+
+        List<Post> postList = postRepository.findAll();
+
+        LocalDateTime expiredDate = LocalDateTime.now().plusDays(EXPIRE_PERIOD);
+        Clock fixedClock = Clock.fixed(
+                expiredDate.atZone(ZoneId.of("Asia/Seoul")).toInstant(),
+                ZoneId.of("Asia/Seoul")
+        );
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
 
         // when
+        postImageDeletionScheduler.deleteExpiredAlarms();
 
         // then
+        assertTrue(storageService.isObjectDeleted(postList.stream().map(Post::getPostImage).toList()));
     }
 
     private Post savePublicPost() throws Exception {


### PR DESCRIPTION
## 📒 개요

30일이 지난 게시물의 이미지를 GCS에서 삭제합니다.

## 📍 Issue 번호

- #146

## 🛠️ 작업사항

- [x] 스케줄러
- [x] clock config
- [x] 스케줄러 테스트

## 🧰 추가 논의사항

- GCS(외부 리소스)에 연결하여 진행하는 테스트이니 만큼, 가끔 한번씩만 돌려주고 머지될때마다 계속 돌려주는건 오히려 부하..가 될 것 같아 일단 gradle 스크립트에서 제외되도록 설정함. 로컬에서는 저거 주석처리하고 돌려주면 됩니다.
- 일단 테스트에서 scheduler 작동되도록 5초를 기다려주는데 어림도 없이 작동을 안함 고쳐야됨
- 삭제된 한달된 게시물 전부를 가져오는 건 애플리케이션에 무리일 것 같아 한 100개 정도 끊어서 가져오고, 삭제하고, 끊어서 가져오고 삭제합니다.
    - 이거 근데.. .. 멀티 스레드로 늘려도 ㄱㅊ을듯 (고민 필요) 찾아보니 스케줄러 기본 설정이 싱글스레드라네요
