### PR TITLE
[Refactor/#157-comment-repository] 차단 회원의 자식 댓글 조회 막기

### DIFF
--- a/src/main/java/com/apps/pochak/comment/controller/CommentController.java
+++ b/src/main/java/com/apps/pochak/comment/controller/CommentController.java
@@ -14,7 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
-import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
+import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
 import static com.apps.pochak.global.api_payload.code.status.SuccessStatus.SUCCESS_DELETE_COMMENT;
 import static com.apps.pochak.global.api_payload.code.status.SuccessStatus.SUCCESS_UPLOAD_COMMENT;
 
@@ -29,7 +29,7 @@ public class CommentController {
     public ApiResponse<CommentElements> getComments(
             @Auth final Accessor accessor,
             @PathVariable("postId") final Long postId,
-            @PageableDefault(DEFAULT_PAGING_SIZE) final Pageable pageable
+            @PageableDefault(COMMENT_PAGING_SIZE) final Pageable pageable
     ) {
         return ApiResponse.onSuccess(
                 commentService.getComments(
@@ -46,7 +46,7 @@ public class CommentController {
             @Auth final Accessor accessor,
             @PathVariable("postId") final Long postId,
             @PathVariable("parentCommentId") final Long parentCommentId,
-            @PageableDefault(DEFAULT_PAGING_SIZE) final Pageable pageable
+            @PageableDefault(COMMENT_PAGING_SIZE) final Pageable pageable
     ) {
         return ApiResponse.onSuccess(
                 commentService.getChildCommentsByParentCommentId(

--- a/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
@@ -49,22 +49,28 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             Pageable pageable
     );
 
-    @Query("select c from Comment c " +
-            "join fetch c.member " +
-            "where c.id = :commentId " +
-            "   and c.parentComment is null " +
-            "   and c.member not in (select b.blockedMember from Block b where b.blocker = :loginMember)" +
-            "   and :loginMember not in (select b.blockedMember from Block b where b.blocker = c.member) ")
+    @Query("""
+            select c from Comment c
+            join fetch c.member
+            where c.id = :commentId
+               and c.parentComment is null
+               and c.member not in (select b.blockedMember from Block b where b.blocker = :loginMember)
+               and :loginMember not in (select b.blockedMember from Block b where b.blocker = c.member)
+            order by c.createdDate desc
+            """)
     Optional<Comment> findParentCommentById(
             @Param("commentId") final Long commentId,
             @Param("loginMember") final Member loginMember
     );
 
-    @Query("select c from Comment c " +
-            "join fetch c.member " +
-            "where c.parentComment = :parentComment " +
-            "   and c.member not in (select b.blockedMember from Block b where b.blocker = :loginMember) " +
-            "   and :loginMember not in (select b.blockedMember from Block b where b.blocker = c.member)")
+    @Query("""
+            select c from Comment c
+            join fetch c.member
+            where c.parentComment = :parentComment
+               and c.member not in (select b.blockedMember from Block b where b.blocker = :loginMember)
+               and :loginMember not in (select b.blockedMember from Block b where b.blocker = c.member)
+            order by c.createdDate desc
+            """)
     Page<Comment> findChildCommentByParentComment(@Param("parentComment") Comment parentComment,
                                                   @Param("loginMember") Member loginMember,
                                                   Pageable pageable);
@@ -73,14 +79,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             select child_comments.*
             from (
                 select c.*,
-                       ROW_NUMBER() OVER (partition by c.parent_comment_id) as row_num
+                       ROW_NUMBER() OVER (partition by c.parent_comment_id order by c.created_date desc) as row_num
                 from comment c
                 join member m on c.member_id = m.id
                 where c.parent_comment_id in ?1
                   and c.member_id not in (select b.blocked_id from block b where b.blocker_id = ?2)
                   and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
             ) child_comments
-            where child_comments.row_num <= 30""", nativeQuery = true)
+            where child_comments.row_num = 1""", nativeQuery = true)
     List<Comment> findChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
 
     @Modifying

--- a/src/main/java/com/apps/pochak/comment/dto/response/CommentElements.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/CommentElements.java
@@ -34,6 +34,7 @@ public class CommentElements {
             for (Comment childComment : childComments) {
                 if (Objects.equals(parentComment.getId(), childComment.getParentComment().getId())) {
                     childCommentList.add(childComment);
+                    break;
                 }
             }
             parentCommentList.add(new ParentCommentElement(parentComment, childCommentList));

--- a/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
@@ -36,7 +36,7 @@ public class ParentCommentElement {
         this(
                 parentComment,
                 childCommentList,
-                PageRequest.of(0, Constant.DEFAULT_PAGING_SIZE)
+                PageRequest.of(0, Constant.COMMENT_PAGING_SIZE)
         );
     }
 

--- a/src/main/java/com/apps/pochak/global/Constant.java
+++ b/src/main/java/com/apps/pochak/global/Constant.java
@@ -9,4 +9,5 @@ public class Constant {
     public static final String HEADER_APPLE_AUTHORIZATION_CODE = "AuthorizationCode";
 
     public static final int DEFAULT_PAGING_SIZE = 30;
+    public static final int COMMENT_PAGING_SIZE = 10;
 }

--- a/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
@@ -23,8 +23,7 @@ import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
 import static com.apps.pochak.member.fixture.MemberFixture.*;
 import static com.apps.pochak.post.fixture.PostFixture.CAPTION;
 import static com.apps.pochak.post.fixture.PostFixture.POST_IMAGE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Transactional
 @SpringBootTest
@@ -69,10 +68,13 @@ class CommentRepositoryTest {
         //when
         Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
         List<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComments(parentCommentByPost.stream().map(Comment::getId).toList(), loginMember.getId());
+
         //then
-        assertTrue(parentCommentByPost.hasContent());
-        assertEquals(parentCommentByPost.getContent().get(0), parentComment);
-        assertEquals(childCommentByParentComment.size(), 1);
+        assertAll(
+                () -> assertTrue(parentCommentByPost.hasContent()),
+                () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment),
+                () -> assertEquals(childCommentByParentComment.size(), 1)
+        );
     }
 
     @DisplayName("[전체 댓글 조회] 부모 댓글의 특정 자식 댓글 차단시")
@@ -80,24 +82,37 @@ class CommentRepositoryTest {
     void findChildCommentByParentCommentsWhenBlocked() {
         //given
         block(childCommenter, loginMember);
+
         //when
-        Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
-        List<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComments(parentCommentByPost.stream().map(Comment::getId).toList(), loginMember.getId());
+        Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(
+                post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE)
+        );
+        List<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComments(
+                parentCommentByPost.stream().map(Comment::getId).toList(), loginMember.getId()
+        );
+
         //then
-        assertTrue(parentCommentByPost.hasContent());
-        assertEquals(parentCommentByPost.getContent().get(0), parentComment);
-        assertEquals(childCommentByParentComment.size(), 0);
+        assertAll(
+                () -> assertTrue(parentCommentByPost.hasContent()),
+                () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment),
+                () -> assertEquals(childCommentByParentComment.size(), 0)
+        );
     }
 
     @DisplayName("[부모 댓글 조회] 정상 테스트")
     @Test
     void findParentCommentByPost() {
         //when
-        Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
+        Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(
+                post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE)
+        );
+
         //then
-        assertTrue(parentCommentByPost.hasContent());
-        assertEquals(parentCommentByPost.getTotalElements(), 1);
-        assertEquals(parentCommentByPost.getContent().get(0), parentComment);
+        assertAll(
+                () -> assertTrue(parentCommentByPost.hasContent()),
+                () -> assertEquals(parentCommentByPost.getTotalElements(), 1),
+                () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment)
+        );
     }
 
     @DisplayName("[부모 댓글 조회] 부모 댓글 작성자 차단시")
@@ -105,8 +120,10 @@ class CommentRepositoryTest {
     void findParentCommentByPostWhenBlocked() {
         //given
         block(parentCommenter, loginMember);
+
         //when
         Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
+
         //then
         assertEquals(parentCommentByPost.getTotalElements(), 0);
     }
@@ -115,7 +132,9 @@ class CommentRepositoryTest {
     @Test
     void findChildCommentByParentComment() {
         //when
-        Page<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComment(parentComment, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
+        Page<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComment(
+                parentComment, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
+
         //then
         assertEquals(childCommentByParentComment.getContent().size(), 1);
         assertEquals(childCommentByParentComment.getContent().get(0), childComment);
@@ -126,15 +145,23 @@ class CommentRepositoryTest {
     void findChildCommentByParentCommentWhenBlocked() {
         //given
         block(childCommenter, loginMember);
+
         //when
-        Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
+        Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(
+                post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE)
+        );
         Page<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComment(
-                        parentCommentByPost.getContent().get(0), loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE)
-                );
+                parentCommentByPost.getContent().get(0),
+                loginMember,
+                PageRequest.of(0, DEFAULT_PAGING_SIZE)
+        );
+
         //then
-        assertTrue(parentCommentByPost.hasContent());
-        assertEquals(parentCommentByPost.getContent().get(0), parentComment);
-        assertEquals(childCommentByParentComment.getContent().size(), 0);
+        assertAll(
+                () -> assertTrue(parentCommentByPost.hasContent()),
+                () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment),
+                () -> assertEquals(childCommentByParentComment.getContent().size(), 0)
+        );
     }
 
     private Post savePost(Member owner) {

--- a/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
@@ -73,7 +73,7 @@ class CommentRepositoryTest {
         assertAll(
                 () -> assertTrue(parentCommentByPost.hasContent()),
                 () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment),
-                () -> assertEquals(childCommentByParentComment.size(), 1)
+                () -> assertEquals(1, childCommentByParentComment.size())
         );
     }
 
@@ -95,7 +95,7 @@ class CommentRepositoryTest {
         assertAll(
                 () -> assertTrue(parentCommentByPost.hasContent()),
                 () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment),
-                () -> assertEquals(childCommentByParentComment.size(), 0)
+                () -> assertEquals(0, childCommentByParentComment.size())
         );
     }
 
@@ -111,7 +111,7 @@ class CommentRepositoryTest {
         assertAll(
                 () -> assertTrue(parentCommentByPost.hasContent()),
                 () -> assertEquals(parentCommentByPost.getTotalElements(), 1),
-                () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment)
+                () -> assertEquals(parentComment, parentCommentByPost.getContent().get(0))
         );
     }
 
@@ -125,7 +125,7 @@ class CommentRepositoryTest {
         Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
 
         //then
-        assertEquals(parentCommentByPost.getTotalElements(), 0);
+        assertEquals(0, parentCommentByPost.getTotalElements());
     }
 
     @DisplayName("[자식 댓글 조회] 정상 테스트")
@@ -137,7 +137,7 @@ class CommentRepositoryTest {
 
         //then
         assertEquals(childCommentByParentComment.getContent().size(), 1);
-        assertEquals(childCommentByParentComment.getContent().get(0), childComment);
+        assertEquals(childComment, childCommentByParentComment.getContent().get(0));
     }
 
     @DisplayName("[자식 댓글 조회] 자식 댓글 작성자 차단시")
@@ -160,7 +160,7 @@ class CommentRepositoryTest {
         assertAll(
                 () -> assertTrue(parentCommentByPost.hasContent()),
                 () -> assertEquals(parentCommentByPost.getContent().get(0), parentComment),
-                () -> assertEquals(childCommentByParentComment.getContent().size(), 0)
+                () -> assertEquals(0, childCommentByParentComment.getContent().size())
         );
     }
 

--- a/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
@@ -7,6 +7,7 @@ import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.post.domain.repository.PostRepository;
+import com.apps.pochak.post.fixture.PostFixture;
 import com.apps.pochak.tag.domain.repository.TagRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,8 +22,6 @@ import java.util.List;
 
 import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
 import static com.apps.pochak.member.fixture.MemberFixture.*;
-import static com.apps.pochak.post.fixture.PostFixture.CAPTION;
-import static com.apps.pochak.post.fixture.PostFixture.POST_IMAGE;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Transactional
@@ -165,7 +164,7 @@ class CommentRepositoryTest {
     }
 
     private Post savePost(Member owner) {
-        Post post = postRepository.save(new Post(owner, POST_IMAGE, CAPTION));
+        Post post = postRepository.save(PostFixture.get(owner));
         post.makePublic();
         return post;
     }

--- a/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
@@ -113,7 +113,7 @@ class CommentServiceTest {
         CommentElements actual = commentService
                 .getComments(
                         Accessor.member(loginMember.getId()),
-                        post.getId()
+                        post.getId(),
                         PageRequest.of(0, COMMENT_PAGING_SIZE)
                 );
         // then

--- a/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
@@ -11,6 +11,7 @@ import com.apps.pochak.member.domain.Member;
 import com.apps.pochak.member.domain.repository.MemberRepository;
 import com.apps.pochak.post.domain.Post;
 import com.apps.pochak.post.domain.repository.PostRepository;
+import com.apps.pochak.post.fixture.PostFixture;
 import com.apps.pochak.tag.domain.repository.TagRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
 import static com.apps.pochak.member.fixture.MemberFixture.*;
-import static com.apps.pochak.post.fixture.PostFixture.CAPTION;
-import static com.apps.pochak.post.fixture.PostFixture.POST_IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -162,7 +161,7 @@ class CommentServiceTest {
     }
 
     private Post savePost(Member owner) {
-        Post post = postRepository.save(new Post(owner, POST_IMAGE, CAPTION));
+        Post post = postRepository.save(PostFixture.get(owner));
         post.makePublic();
         return post;
     }

--- a/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
+import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
 import static com.apps.pochak.member.fixture.MemberFixture.*;
 import static com.apps.pochak.post.fixture.PostFixture.CAPTION;
 import static com.apps.pochak.post.fixture.PostFixture.POST_IMAGE;
@@ -79,7 +79,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, DEFAULT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE)
                 );
         // then
         assertAll(
@@ -99,7 +99,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, DEFAULT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE)
                 );
         // then
         assertThat(actual.getParentCommentList()).hasSize(0);
@@ -115,7 +115,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, DEFAULT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE)
                 );
         // then
         assertThat(actual.getParentCommentList()).hasSize(0);
@@ -131,7 +131,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, DEFAULT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE)
                 );
         // then
         assertAll(
@@ -151,7 +151,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, DEFAULT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE)
                 );
         // then
         assertAll(


### PR DESCRIPTION
## 📒 개요

차단 회원의 자식 댓글 조회 막기

## 📍 Issue 번호

- #157 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] 쿼리
- [x] 레포 테스트
- [x] element 수정
- [x] 서비스 수정
- [x] 컨트롤러 테스트

## 🧰 추가 논의사항

- 자식 댓글을 원래 element에서 페이징 처리를 해줬는데 쿼리로 받아오니까 서비스에서 해줘야할지 ...? 
- 네이티브 쿼리에 최초 조회 건수 하드코딩 해놓음
