### PR TITLE
[Feat/#160-memories-getF4FStatus-api] 추억페이지 맞팔 상태 조회

### DIFF
--- a/src/docs/asciidoc/memories.adoc
+++ b/src/docs/asciidoc/memories.adoc
@@ -92,3 +92,21 @@ include::{snippets}/get-memories-pochak/query-parameters.adoc[]
 ==== response body
 include::{snippets}/get-memories-pochak/response-body.adoc[]
 include::{snippets}/get-memories-pochak/response-fields.adoc[]
+
+== `GET` F4F Status
+추억 페이지 맞팔 상태 조회 API
+
+=== Request
+
+include::{snippets}/get-F4F-status/http-request.adoc[]
+
+==== request headers
+include::{snippets}/get-F4F-status/request-headers.adoc[]
+
+==== path params
+include::{snippets}/get-F4F-status/path-parameters.adoc[]
+
+=== Response
+==== response body
+include::{snippets}/get-F4F-status/response-body.adoc[]
+include::{snippets}/get-F4F-status/response-fields.adoc[]

--- a/src/main/java/com/apps/pochak/member/dto/response/ProfileResponse.java
+++ b/src/main/java/com/apps/pochak/member/dto/response/ProfileResponse.java
@@ -25,6 +25,7 @@ public class ProfileResponse {
     private long followerCount;
     private long followingCount;
     private Boolean isFollow;
+    private Boolean isF4F;
     private PageInfo pageInfo;
     private List<PostElement> postList;
 
@@ -33,6 +34,7 @@ public class ProfileResponse {
                            final long followerCount,
                            final long followingCount,
                            final Boolean isFollow,
+                           final Boolean isF4F,
                            final Page<Post> postPage
     ) {
         this.handle = member.getHandle();
@@ -43,6 +45,7 @@ public class ProfileResponse {
         this.followerCount = followerCount;
         this.followingCount = followingCount;
         this.isFollow = isFollow;
+        this.isF4F = isF4F;
         this.pageInfo = new PageInfo(postPage);
         this.postList = postPage.getContent().stream().map(
                 PostElement::from

--- a/src/main/java/com/apps/pochak/member/service/MemberService.java
+++ b/src/main/java/com/apps/pochak/member/service/MemberService.java
@@ -46,6 +46,9 @@ public class MemberService {
         final Page<Post> taggedPost = postRepository.findTaggedPost(member, loginMember, pageable);
         final Boolean isFollow = (handle.equals(loginMember.getHandle())) ?
                 null : followRepository.existsBySenderAndReceiver(loginMember, member);
+        final Boolean isF4F = (handle.equals(loginMember.getHandle())) ?
+                null : followRepository.existsBySenderAndReceiver(loginMember, member)
+                && followRepository.existsBySenderAndReceiver(member, loginMember);
 
         return ProfileResponse.of()
                 .member(member)
@@ -53,6 +56,7 @@ public class MemberService {
                 .followerCount(followerCount)
                 .followingCount(followingCount)
                 .isFollow(isFollow)
+                .isF4F(isF4F)
                 .build();
     }
 

--- a/src/main/java/com/apps/pochak/memories/controller/MemoriesController.java
+++ b/src/main/java/com/apps/pochak/memories/controller/MemoriesController.java
@@ -19,12 +19,12 @@ import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/memories")
+@RequestMapping("api/v1/memories/{handle}")
 public class MemoriesController {
 
     private final MemoriesService memoriesService;
 
-    @GetMapping("{handle}")
+    @GetMapping("")
     @MemberOnly
     public ApiResponse<MemoriesPreviewResponse> getMemories(
             @Auth final Accessor accessor,
@@ -33,7 +33,7 @@ public class MemoriesController {
         return ApiResponse.onSuccess(memoriesService.getMemories(accessor, handle));
     }
 
-    @GetMapping("{handle}/pochak")
+    @GetMapping("/pochak")
     @MemberOnly
     public ApiResponse<MemoriesPostResponse> getPochak(
             @Auth final Accessor accessor,
@@ -43,7 +43,7 @@ public class MemoriesController {
         return ApiResponse.onSuccess(memoriesService.getPochak(accessor, handle, pageable));
     }
 
-    @GetMapping("{handle}/pochaked")
+    @GetMapping("/pochaked")
     @MemberOnly
     public ApiResponse<MemoriesPostResponse> getPochaked(
             @Auth final Accessor accessor,
@@ -53,7 +53,7 @@ public class MemoriesController {
         return ApiResponse.onSuccess(memoriesService.getPochaked(accessor, handle, pageable));
     }
 
-    @GetMapping("{handle}/bonded")
+    @GetMapping("/bonded")
     @MemberOnly
     public ApiResponse<MemoriesPostResponse> getBonded(
             @Auth final Accessor accessor,
@@ -63,4 +63,12 @@ public class MemoriesController {
         return ApiResponse.onSuccess(memoriesService.getBonded(accessor, handle, pageable));
     }
 
+    @GetMapping("/f4f/status")
+    @MemberOnly
+    public ApiResponse<Boolean> getF4FStatus(
+            @Auth final Accessor accessor,
+            @PathVariable("handle") final String handle
+    ) {
+        return ApiResponse.onSuccess(memoriesService.getF4FStatus(accessor, handle));
+    }
 }

--- a/src/main/java/com/apps/pochak/memories/service/MemoriesService.java
+++ b/src/main/java/com/apps/pochak/memories/service/MemoriesService.java
@@ -104,4 +104,14 @@ public class MemoriesService {
         final Page<Tag> tag = tagRepository.findTaggedWith(loginMember, member, pageable);
         return MemoriesPostResponse.from(tag);
     }
+
+    public Boolean getF4FStatus(Accessor accessor, String handle) {
+        final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
+        final Member member = memberRepository.findByHandle(handle, loginMember);
+
+        final boolean following = followRepository.existsBySenderAndReceiver(loginMember, member);
+        final boolean follower = followRepository.existsBySenderAndReceiver(member, loginMember);
+
+        return following && follower;
+    }
 }

--- a/src/test/java/com/apps/pochak/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/apps/pochak/member/controller/MemberControllerTest.java
@@ -80,6 +80,7 @@ class MemberControllerTest extends ControllerTest {
                                 .followerCount(1)
                                 .followingCount(1)
                                 .isFollow(null)
+                                .isF4F(true)
                                 .build()
                 );
 
@@ -116,6 +117,9 @@ class MemberControllerTest extends ControllerTest {
                                         fieldWithPath("result.followingCount").type(NUMBER).description("팔로잉 수"),
                                         fieldWithPath("result.isFollow").type(BOOLEAN)
                                                 .description("현재 로그인한 멤버가 조회한 멤버를 팔로우하고 있는지의 여부 : 만약 본인이라면 null이 전달됩니다.")
+                                                .optional(),
+                                        fieldWithPath("result.isF4F").type(BOOLEAN)
+                                                .description("현재 로그인한 멤버가 조회한 멤버와 맞팔로우하고 있는지의 여부 : 만약 본인이라면 null이 전달됩니다.")
                                                 .optional(),
                                         fieldWithPath("result.pageInfo").type(OBJECT).description("게시물 페이징 정보"),
                                         fieldWithPath("result.pageInfo.lastPage").type(BOOLEAN)

--- a/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
+++ b/src/test/java/com/apps/pochak/memories/controller/MemoriesControllerTest.java
@@ -326,4 +326,36 @@ class MemoriesControllerTest extends ControllerTest {
                         )
                 );
     }
+
+    @Test
+    @DisplayName("[추억 페이지] 상대방과의 맞팔 상태를 조회한다.")
+    void getF4FStatus() throws Exception {
+        when(memoriesService.getF4FStatus(any(), any()))
+                .thenReturn(true);
+
+        this.mockMvc.perform(
+                        RestDocumentationRequestBuilders
+                                .get("/api/v1/memories/{handle}/f4f/status", "member2")
+                                .header(ACCESS_TOKEN_HEADER, ACCESS_TOKEN)
+                                .contentType(APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andDo(
+                        document("get-f4f-status",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(
+                                        headerWithName("Authorization").description("Basic auth credentials")
+                                ),
+                                pathParameters(
+                                        parameterWithName("handle").description("친구의 아이디")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").type(BOOLEAN).description("성공 여부"),
+                                        fieldWithPath("code").type(STRING).description("결과 코드"),
+                                        fieldWithPath("message").type(STRING).description("결과 메세지"),
+                                        fieldWithPath("result").type(BOOLEAN).description("결과 데이터")
+                                )
+                        )
+                );
+    }
 }


### PR DESCRIPTION
## 📒 개요

추억페이지 맞팔 상태 조회

## 📍 Issue 번호

- #160 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] 컨트롤러
- [x] 서비스

## 🧰 추가 논의사항

- ![image](https://github.com/user-attachments/assets/b82f6b17-9fb1-4745-93ad-a835dc5c5191)
- 이거 아이디 넘겨주는 걸로 리팩토링하면 어떨지요 멤버 조회가 불필요해서
