### PR TITLE
[Fix/#108-profile-update-validation] 프로필 수정시 유효성 검사를 한다

### DIFF
--- a/src/main/java/com/apps/pochak/member/controller/MemberController.java
+++ b/src/main/java/com/apps/pochak/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.apps.pochak.member.dto.response.MemberElements;
 import com.apps.pochak.member.dto.response.ProfileUpdateResponse;
 import com.apps.pochak.member.service.MemberService;
 import com.apps.pochak.post.dto.PostElements;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -70,7 +71,7 @@ public class MemberController {
     public ApiResponse<ProfileUpdateResponse> updateProfile(
             @Auth final Accessor accessor,
             @PathVariable("handle") final String handle,
-            @ModelAttribute final ProfileUpdateRequest profileUpdateRequest) {
+            @ModelAttribute @Valid final ProfileUpdateRequest profileUpdateRequest) {
         return ApiResponse.onSuccess(
                 memberService.updateProfile(
                         accessor,

--- a/src/main/java/com/apps/pochak/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/apps/pochak/member/dto/request/ProfileUpdateRequest.java
@@ -13,7 +13,6 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProfileUpdateRequest {
-    @NotNull(message = "사용자의 이름은 필수입니다.")
     @NotBlank(message = "이름은 공백이 될 수 없습니다.")
     @Size(max = 15, message = "이름은 최대 15자까지 가능합니다.")
     private String name;

--- a/src/test/java/com/apps/pochak/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/apps/pochak/member/controller/MemberControllerTest.java
@@ -27,8 +27,7 @@ import static com.apps.pochak.global.ApiDocumentUtils.getDocumentRequest;
 import static com.apps.pochak.global.ApiDocumentUtils.getDocumentResponse;
 import static com.apps.pochak.global.MockMultipartFileConverter.getMockMultipartFileOfMember;
 import static com.apps.pochak.global.converter.ListToPageConverter.toPage;
-import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER1;
-import static com.apps.pochak.member.fixture.MemberFixture.STATIC_MEMBER2;
+import static com.apps.pochak.member.fixture.MemberFixture.*;
 import static com.apps.pochak.post.fixture.PostFixture.STATIC_PUBLIC_POST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -42,6 +41,8 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureRestDocs
@@ -50,6 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class MemberControllerTest extends ControllerTest {
     private static final Member MEMBER1 = STATIC_MEMBER1;
     private static final Member MEMBER2 = STATIC_MEMBER2;
+    private static final Member MEMBER3 = WRONG_MEMBER;
     private static final Post PUBLIC_POST = STATIC_PUBLIC_POST;
 
     private static final List<Member> MEMBER_LIST = List.of(
@@ -272,6 +274,17 @@ class MemberControllerTest extends ControllerTest {
                                 )
                         )
                 );
+    }
+
+    @Test
+    @DisplayName("프로필 수정 유효성 검사를 한다.")
+    void updateProfileValidationTest() throws Exception {
+        this.mockMvc.perform(
+                put("/api/v2/members/{handle}", MEMBER3.getHandle())
+                        .queryParam("name", MEMBER3.getName())
+                        .queryParam("message", MEMBER3.getMessage())
+                        .contentType(APPLICATION_JSON)
+        ).andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
+++ b/src/test/java/com/apps/pochak/member/fixture/MemberFixture.java
@@ -37,13 +37,16 @@ public class MemberFixture {
 
     public static final Member WRONG_MEMBER = new Member(
             3L,
+//            "wrong_member",
             ".wrong_member#",
-            "공백이 아닌 열다섯자 이내인 회원의 이름",
+//            "null",
+            null,
+//            "",
             """
             1
             2
             3
-            3줄 이내
+            4
             """,
             "aaa@pochak.com",
             null,


### PR DESCRIPTION
## 📒 개요

- 프로필 수정시 이름 null 허용
- 컨트롤러 테스트

## 📍 Issue 번호

- #108 
