### PR TITLE
[fix/#175-signup-image] 회원가입 완료 후 회원 프로필 이미지 전달

### DIFF
--- a/src/main/java/com/apps/pochak/login/dto/response/OAuthMemberResponse.java
+++ b/src/main/java/com/apps/pochak/login/dto/response/OAuthMemberResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class OAuthMemberResponse {
     private Long id;
     private String socialId;
+    private String profileImage;
     private String name;
     private String email;
     private String handle;
@@ -17,7 +18,6 @@ public class OAuthMemberResponse {
     private String accessToken;
     private String refreshToken;
     private Boolean isNewMember;
-
 
     @Builder
     public OAuthMemberResponse(
@@ -47,6 +47,7 @@ public class OAuthMemberResponse {
     ) {
         this.id = member.getId();
         this.socialId = member.getSocialId();
+        this.profileImage = member.getProfileImage();
         this.name = member.getName();
         this.email = member.getEmail();
         this.handle = member.getHandle();

--- a/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
+++ b/src/test/java/com/apps/pochak/login/controller/OAuthControllerTest.java
@@ -108,6 +108,7 @@ public class OAuthControllerTest extends ControllerTest {
                                         fieldWithPath("result").type(OBJECT).description("결과 데이터"),
                                         fieldWithPath("result.id").type(NUMBER).description("멤버 아이디"),
                                         fieldWithPath("result.socialId").type(STRING).description("소셜 아이디"),
+                                        fieldWithPath("result.profileImage").type(STRING).description("프로필 사진"),
                                         fieldWithPath("result.name").type(STRING).description("회원 이름"),
                                         fieldWithPath("result.email").type(STRING).description("회원 이메일"),
                                         fieldWithPath("result.handle").type(STRING).description("회원 아이디 (핸들)"),


### PR DESCRIPTION
## 📒 개요

가입 완료된 회원의 프로필 이미지를 전달합니다.

## 📍 Issue 번호

- #175 

## 🛠️ 작업사항

- [x] dto 수정
- [x] api 문서 수정
