### PR TITLE
[HotFix/#76-jacoco-sonar] 빌드 실패, 의존성 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,7 @@ Qdomains.add("com/apps/pochak/**/dto/**")
 
 jacocoTestReport {
     dependsOn test
+    dependsOn copyDocument
 
     reports {
         xml.required.set(true)


### PR DESCRIPTION
## 📒 개요
- 기존 #76 작업 시, 빌드 실패

## 📍 Issue 번호
#76 

## 🛠️ 작업사항
- [x] build.gradle 설정

## 🧰 추가 논의사항
