### PR TITLE
[Feat/#179-prometheus-grafana] prometheus, grafana 도입

### DIFF
--- a/.github/workflows/dev-server.yml
+++ b/.github/workflows/dev-server.yml
@@ -74,4 +74,4 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             sudo sh deploy.sh
-            docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus --network pochak-dev_default -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml
+#            docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus --network pochak-dev_default -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml

--- a/.github/workflows/dev-server.yml
+++ b/.github/workflows/dev-server.yml
@@ -72,5 +72,4 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          script: |
-            sudo sh deploy.sh
+          script: sudo sh deploy.sh

--- a/.github/workflows/dev-server.yml
+++ b/.github/workflows/dev-server.yml
@@ -73,3 +73,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: sudo sh deploy.sh
+
+      - name: Add Prometheus
+        run: docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml
+        shell: bash

--- a/.github/workflows/dev-server.yml
+++ b/.github/workflows/dev-server.yml
@@ -72,8 +72,6 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          script: sudo sh deploy.sh
-
-      - name: Add Prometheus
-        run: docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml
-        shell: bash
+          script: |
+            sudo sh deploy.sh
+            docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml

--- a/.github/workflows/dev-server.yml
+++ b/.github/workflows/dev-server.yml
@@ -74,4 +74,4 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             sudo sh deploy.sh
-            docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml
+            docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus --network pochak-dev_default -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml

--- a/.github/workflows/dev-server.yml
+++ b/.github/workflows/dev-server.yml
@@ -74,4 +74,3 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             sudo sh deploy.sh
-#            docker run -p 9090:9090 -v /home/ubuntu/prometheus/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml --name prometheus --network pochak-dev_default -d prom/prometheus --config.file=/etc/prometheus/prometheus.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:17-jdk
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-EXPOSE 3000
+EXPOSE 5000
 
 ARG SPRING_PROFILES_ACTIVE
 ARG JASYPT_KEY

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: "com.vaadin.external.google", module: "android-json"
     }
@@ -60,6 +61,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     testCompileOnly 'org.projectlombok:lombok:1.18.34'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,6 @@ spring.profiles.group.PROD=PROD, COMMON
 
 # jasypt
 jasypt.encryptor.password=${JASYPT_KEY}
+
+# actuator
+management.endpoints.web.exposure.include=health, info, prometheus

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,4 +21,4 @@ spring.profiles.group.PROD=PROD, COMMON
 jasypt.encryptor.password=${JASYPT_KEY}
 
 # actuator
-management.endpoints.web.exposure.include=health, info, prometheus
+management.endpoints.web.exposure.include=*

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,4 +21,4 @@ spring.profiles.group.PROD=PROD, COMMON
 jasypt.encryptor.password=${JASYPT_KEY}
 
 # actuator
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health, prometheus, info


### PR DESCRIPTION
## 📒 개요

prometheus와 grafana를 도입해 모니터링합니다

## 📍 Issue 번호

- #179 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] spring에서 엔드포인트 설정 
    1. actuator 의존성 추가
    2. prometheus 의존성 추가
    3. 외부 접근 허용
- [x] docker-compose.yml 에 node_exporter 컨테이너, prometheus컨테이너 추가
  - [x] prometheus 볼륨 추가
- [x] prometheus-8080.yml, prometheus-8081.yml
  - [x] node_exporter(host) 타겟으로 job 추가 : [`http://node_exporter:9100`](http://node_exporter:9100) 호스트 모니터링
  - [x] app 타겟으로 job 추가 : [`http://pochak-dev:8080`](http://pochak-dev:8080) 
- [x] 그라파나 컨테이너 추가 (3000포트 열기)
  - [x] 로그인 설정
  - [x] https://grafana.com/grafana/dashboards/?search=spring+boot 대쉬보드 설정 (spring boot 2.1 system monitor)
  - [x] 볼륨 추가
- [x] 방화벽 규칙 설정

## 🧰 추가 논의사항
![image](https://github.com/user-attachments/assets/e6f568cc-4732-4ab8-805e-326ce354a495)

![image](https://github.com/user-attachments/assets/77f9cea1-b0fa-4b60-b115-6f735cc87921)

```
    prometheus:
      image: prom/prometheus:v2.17.2
      ports:
        - "9090:9090"
      container_name: prometheus
      command:
        - '--config.file=/etc/prometheus/prometheus.yml'
        - '--storage.tsdb.path=/prometheus'
        - '--web.console.libraries=/etc/prometheus/console_libraries'
        - '--web.console.templates=/etc/prometheus/consoles'
        - '--storage.tsdb.retention.time=1y'
        - '--web.enable-lifecycle'
      hostname: prometheus
      volumes:
        - type: bind
          source: ./config/prometheus.yml
          target: /etc/prometheus/prometheus.yml
          read_only: true
        - prometheus:/prometheus
```
- storage retention 기간 설정 추가
- CPU 사용량에 따른 alert 추가
