### PR TITLE
[Refactor/#189-sort-comment] Comment 정렬 조건 추가하기

### DIFF
--- a/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
@@ -85,7 +85,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                   and c.member_id not in (select b.blocked_id from block b where b.blocker_id = ?2)
                   and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
             ) child_comments
-            where child_comments.row_num = 1""", nativeQuery = true)
+            where child_comments.row_num <= 2""", nativeQuery = true)
     List<Comment> findFirstChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
 
     @Query(value = """
@@ -99,7 +99,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                   and c.member_id not in (select b.blocked_id from block b where b.blocker_id = ?2)
                   and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
             ) child_comments
-            where child_comments.row_num = 1""", nativeQuery = true)
+            where child_comments.row_num <= 2""", nativeQuery = true)
     List<Comment> findLatestChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
 
     @Modifying

--- a/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
@@ -69,11 +69,24 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             where c.parentComment = :parentComment
                and c.member not in (select b.blockedMember from Block b where b.blocker = :loginMember)
                and :loginMember not in (select b.blockedMember from Block b where b.blocker = c.member)
-            order by c.createdDate desc
             """)
     Page<Comment> findChildCommentByParentComment(@Param("parentComment") Comment parentComment,
                                                   @Param("loginMember") Member loginMember,
                                                   Pageable pageable);
+
+    @Query(value = """
+            select child_comments.*
+            from (
+                select c.*,
+                       ROW_NUMBER() OVER (partition by c.parent_comment_id order by c.created_date asc) as row_num
+                from comment c
+                join member m on c.member_id = m.id
+                where c.parent_comment_id in ?1
+                  and c.member_id not in (select b.blocked_id from block b where b.blocker_id = ?2)
+                  and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
+            ) child_comments
+            where child_comments.row_num = 1""", nativeQuery = true)
+    List<Comment> findFirstChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
 
     @Query(value = """
             select child_comments.*
@@ -87,7 +100,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                   and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
             ) child_comments
             where child_comments.row_num = 1""", nativeQuery = true)
-    List<Comment> findChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
+    List<Comment> findLatestChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
 
     @Modifying
     @Query("update Comment c set c.status = 'DELETED' " +

--- a/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/apps/pochak/comment/domain/repository/CommentRepository.java
@@ -84,6 +84,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                 where c.parent_comment_id in ?1
                   and c.member_id not in (select b.blocked_id from block b where b.blocker_id = ?2)
                   and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
+                order by c.created_date asc
             ) child_comments
             where child_comments.row_num <= 2""", nativeQuery = true)
     List<Comment> findFirstChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);
@@ -98,6 +99,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                 where c.parent_comment_id in ?1
                   and c.member_id not in (select b.blocked_id from block b where b.blocker_id = ?2)
                   and ?2 not in (select b.blocked_id from block b where b.blocker_id = c.member_id)
+                order by c.created_date desc
             ) child_comments
             where child_comments.row_num <= 2""", nativeQuery = true)
     List<Comment> findLatestChildCommentByParentComments(List<Long> parentCommentIds, Long loginMemberId);

--- a/src/main/java/com/apps/pochak/comment/dto/response/CommentElements.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/CommentElements.java
@@ -33,7 +33,7 @@ public class CommentElements {
             for (Comment childComment : childComments) {
                 if (Objects.equals(parentComment.getId(), childComment.getParentComment().getId())) {
                     childCommentList.add(childComment);
-                    break;
+                    if (childCommentList.size() == 2) break;
                 }
             }
             parentCommentList.add(new ParentCommentElement(parentComment, childCommentList));

--- a/src/main/java/com/apps/pochak/comment/dto/response/CommentElements.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/CommentElements.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
@@ -35,14 +35,14 @@ public class ParentCommentElement {
     ) {
         this(
                 parentComment,
-                childCommentList,
+                toPage(childCommentList),
                 PageRequest.of(0, Constant.COMMENT_PAGING_SIZE)
         );
     }
 
     public ParentCommentElement(
             final Comment parentComment,
-            final List<Comment> childCommentList,
+            final Page<Comment> childCommentList,
             final PageRequest pageRequest
     ) {
         final Member member = parentComment.getMember();
@@ -52,16 +52,11 @@ public class ParentCommentElement {
         this.handle = member.getHandle();
         this.createdDate = parentComment.getCreatedDate();
         this.content = parentComment.getContent();
-
-        final List<CommentElement> commentElementList = childCommentList.stream()
+        this.childCommentPageInfo = new PageInfo(childCommentList);
+        this.childCommentList = childCommentList.stream()
                 .map(
                         CommentElement::new
                 )
                 .collect(Collectors.toList());
-
-        final Page<CommentElement> commentElementPage = toPage(commentElementList, pageRequest);
-
-        this.childCommentPageInfo = new PageInfo(commentElementPage);
-        this.childCommentList = commentElementPage.getContent();
     }
 }

--- a/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
+++ b/src/main/java/com/apps/pochak/comment/dto/response/ParentCommentElement.java
@@ -1,7 +1,6 @@
 package com.apps.pochak.comment.dto.response;
 
 import com.apps.pochak.comment.domain.Comment;
-import com.apps.pochak.global.Constant;
 import com.apps.pochak.global.util.PageInfo;
 import com.apps.pochak.member.domain.Member;
 import lombok.AllArgsConstructor;
@@ -35,15 +34,13 @@ public class ParentCommentElement {
     ) {
         this(
                 parentComment,
-                toPage(childCommentList),
-                PageRequest.of(0, Constant.COMMENT_PAGING_SIZE)
+                toPage(childCommentList, PageRequest.of(0, 1))
         );
     }
 
     public ParentCommentElement(
             final Comment parentComment,
-            final Page<Comment> childCommentList,
-            final PageRequest pageRequest
+            final Page<Comment> childCommentList
     ) {
         final Member member = parentComment.getMember();
         this.commentId = parentComment.getId();

--- a/src/main/java/com/apps/pochak/comment/service/CommentService.java
+++ b/src/main/java/com/apps/pochak/comment/service/CommentService.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.*;
-import static com.apps.pochak.global.converter.PageableToPageRequestConverter.toPageRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -75,7 +74,7 @@ public class CommentService {
         final Page<Comment> childComment = commentRepository.findChildCommentByParentComment(
                 parentComment, loginMember, pageable
         );
-        return new ParentCommentElement(parentComment, childComment, toPageRequest(pageable));
+        return new ParentCommentElement(parentComment, childComment);
     }
 
     public void saveComment(

--- a/src/main/java/com/apps/pochak/comment/service/CommentService.java
+++ b/src/main/java/com/apps/pochak/comment/service/CommentService.java
@@ -15,10 +15,8 @@ import com.apps.pochak.post.domain.repository.PostRepository;
 import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.domain.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/apps/pochak/comment/service/CommentService.java
+++ b/src/main/java/com/apps/pochak/comment/service/CommentService.java
@@ -17,10 +17,12 @@ import com.apps.pochak.tag.domain.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.apps.pochak.global.api_payload.code.status.ErrorStatus.*;
 import static com.apps.pochak.global.converter.PageableToPageRequestConverter.toPageRequest;
@@ -45,11 +47,19 @@ public class CommentService {
         final Member loginMember = memberRepository.findMemberById(accessor.getMemberId());
         final Post post = postRepository.findPublicPostById(postId);
         final Page<Comment> parentCommentList = commentRepository.findParentCommentByPost(post, loginMember, pageable);
-        final List<Comment> childCommentList = commentRepository.findChildCommentByParentComments(
-                parentCommentList.stream().map(Comment::getId).toList(),
-                loginMember.getId()
-        );
 
+        List<Comment> childCommentList = null;
+        if (Objects.requireNonNull(pageable.getSort().getOrderFor("createdDate")).isDescending()) {
+            childCommentList = commentRepository.findLatestChildCommentByParentComments(
+                    parentCommentList.stream().map(Comment::getId).toList(),
+                    loginMember.getId()
+            );
+        } else {
+            childCommentList = commentRepository.findFirstChildCommentByParentComments(
+                    parentCommentList.stream().map(Comment::getId).toList(),
+                    loginMember.getId()
+            );
+        }
         return new CommentElements(loginMember, parentCommentList, childCommentList);
     }
 

--- a/src/main/java/com/apps/pochak/comment/service/CommentService.java
+++ b/src/main/java/com/apps/pochak/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import com.apps.pochak.post.domain.repository.PostRepository;
 import com.apps.pochak.tag.domain.Tag;
 import com.apps.pochak.tag.domain.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -76,7 +77,7 @@ public class CommentService {
         final Page<Comment> childComment = commentRepository.findChildCommentByParentComment(
                 parentComment, loginMember, pageable
         );
-        return new ParentCommentElement(parentComment, childComment.getContent(), toPageRequest(pageable));
+        return new ParentCommentElement(parentComment, childComment, toPageRequest(pageable));
     }
 
     public void saveComment(

--- a/src/main/java/com/apps/pochak/global/converter/ListToPageConverter.java
+++ b/src/main/java/com/apps/pochak/global/converter/ListToPageConverter.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import java.util.List;
 
 import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
+import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
 
 public class ListToPageConverter {
     public static <T> Page<T> toPage(List<T> list, PageRequest pageRequest) {
@@ -21,7 +22,7 @@ public class ListToPageConverter {
     }
 
     public static <T> Page<T> toPage(List<T> list) {
-        PageRequest pageRequest = PageRequest.of(0, COMMENT_PAGING_SIZE);
+        PageRequest pageRequest = PageRequest.of(0, DEFAULT_PAGING_SIZE);
         return toPage(list, pageRequest);
     }
 }

--- a/src/main/java/com/apps/pochak/global/converter/ListToPageConverter.java
+++ b/src/main/java/com/apps/pochak/global/converter/ListToPageConverter.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
-import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
 import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
 
 public class ListToPageConverter {

--- a/src/main/java/com/apps/pochak/global/converter/ListToPageConverter.java
+++ b/src/main/java/com/apps/pochak/global/converter/ListToPageConverter.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
-import static com.apps.pochak.global.Constant.DEFAULT_PAGING_SIZE;
+import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
 
 public class ListToPageConverter {
     public static <T> Page<T> toPage(List<T> list, PageRequest pageRequest) {
@@ -21,7 +21,7 @@ public class ListToPageConverter {
     }
 
     public static <T> Page<T> toPage(List<T> list) {
-        PageRequest pageRequest = PageRequest.of(0, DEFAULT_PAGING_SIZE);
+        PageRequest pageRequest = PageRequest.of(0, COMMENT_PAGING_SIZE);
         return toPage(list, pageRequest);
     }
 }

--- a/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/apps/pochak/comment/domain/repository/CommentRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -62,11 +63,11 @@ class CommentRepositoryTest {
 
     @DisplayName("[전체 댓글 조회] 부모 댓글과 자식 댓글")
     @Test
-    void findChildCommentByParentComments() {
+    void findFirstChildCommentByParentComments() {
         //given
         //when
         Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
-        List<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComments(parentCommentByPost.stream().map(Comment::getId).toList(), loginMember.getId());
+        List<Comment> childCommentByParentComment = commentRepository.findFirstChildCommentByParentComments(parentCommentByPost.stream().map(Comment::getId).toList(), loginMember.getId());
         //then
         assertAll(
                 () -> assertTrue(parentCommentByPost.hasContent()),
@@ -77,14 +78,14 @@ class CommentRepositoryTest {
 
     @DisplayName("[전체 댓글 조회] 부모 댓글의 특정 자식 댓글 차단시")
     @Test
-    void findChildCommentByParentCommentsWhenBlocked() {
+    void findFirstChildCommentByParentCommentsWhenBlocked() {
         //given
         block(childCommenter, loginMember);
         //when
         Page<Comment> parentCommentByPost = commentRepository.findParentCommentByPost(
                 post, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE)
         );
-        List<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComments(
+        List<Comment> childCommentByParentComment = commentRepository.findFirstChildCommentByParentComments(
                 parentCommentByPost.stream().map(Comment::getId).toList(), loginMember.getId()
         );
 
@@ -130,8 +131,7 @@ class CommentRepositoryTest {
     void findChildCommentByParentComment() {
         //when
         Page<Comment> childCommentByParentComment = commentRepository.findChildCommentByParentComment(
-                parentComment, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE));
-
+                parentComment, loginMember, PageRequest.of(0, DEFAULT_PAGING_SIZE, Sort.by(Sort.Direction.DESC, "createdDate")));
         //then
         assertEquals(childCommentByParentComment.getContent().size(), 1);
         assertEquals(childComment, childCommentByParentComment.getContent().get(0));

--- a/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
@@ -90,8 +90,8 @@ class CommentServiceTest {
         // then
         assertAll(
                 () -> assertThat(actual.getParentCommentList()).hasSize(1),
-                () -> assertEquals(actual.getParentCommentList().get(0).getChildCommentList().size(), 1),
-                () -> assertEquals(actual.getParentCommentList().get(0).getChildCommentList().get(0), expectedChild)
+                () -> assertEquals(1, actual.getParentCommentList().get(0).getChildCommentList().size()),
+                () -> assertEquals(expectedChild, actual.getParentCommentList().get(0).getChildCommentList().get(0))
         );
     }
 
@@ -108,7 +108,7 @@ class CommentServiceTest {
                         PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.ASC, "createdDate"))
                 );
         // then
-        assertThat(actual.getParentCommentList()).hasSize(0);
+        assertThat(actual.getParentCommentList()).isEmpty();
     }
 
     @Test
@@ -124,7 +124,7 @@ class CommentServiceTest {
                         PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.ASC, "createdDate"))
                 );
         // then
-        assertThat(actual.getParentCommentList()).hasSize(0);
+        assertThat(actual.getParentCommentList()).isEmpty();
     }
 
     @Test
@@ -142,8 +142,8 @@ class CommentServiceTest {
         // then
         assertAll(
                 () -> assertThat(actual.getParentCommentList()).hasSize(1),
-                () -> assertEquals(actual.getParentCommentList().get(0).getCommentId(), parentComment.getId()),
-                () -> assertThat(actual.getParentCommentList().get(0).getChildCommentList()).hasSize(0)
+                () -> assertEquals(parentComment.getId(), actual.getParentCommentList().get(0).getCommentId()),
+                () -> assertThat(actual.getParentCommentList().get(0).getChildCommentList()).isEmpty()
         );
     }
 
@@ -162,8 +162,8 @@ class CommentServiceTest {
         // then
         assertAll(
                 () -> assertThat(actual.getParentCommentList()).hasSize(1),
-                () -> assertEquals(actual.getParentCommentList().get(0).getCommentId(), parentComment.getId()),
-                () -> assertThat(actual.getParentCommentList().get(0).getChildCommentList()).hasSize(0)
+                () -> assertEquals(parentComment.getId(), actual.getParentCommentList().get(0).getCommentId()),
+                () -> assertThat(actual.getParentCommentList().get(0).getChildCommentList()).isEmpty()
         );
     }
 

--- a/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.apps.pochak.global.Constant.COMMENT_PAGING_SIZE;
@@ -55,6 +56,7 @@ class CommentServiceTest {
     private Post post;
     private Comment parentComment;
     private Comment childComment;
+    private Comment childComment2;
 
     @BeforeEach
     void setUp() {
@@ -70,15 +72,17 @@ class CommentServiceTest {
     @DisplayName("[전체 댓글 조회] 정상 테스트")
     void getComments() {
         // given
+        childComment2 = saveChildComment(childCommenter, post, parentComment);
+
         CommentElement expectedChild = CommentElement.from()
-                .comment(childComment)
+                .comment(childComment2)
                 .build();
         // then
         CommentElements actual = commentService
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, COMMENT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.DESC, "createdDate"))
                 );
         // then
         assertAll(
@@ -98,7 +102,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, COMMENT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.ASC, "createdDate"))
                 );
         // then
         assertThat(actual.getParentCommentList()).hasSize(0);
@@ -114,7 +118,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, COMMENT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.ASC, "createdDate"))
                 );
         // then
         assertThat(actual.getParentCommentList()).hasSize(0);
@@ -130,7 +134,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, COMMENT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.ASC, "createdDate"))
                 );
         // then
         assertAll(
@@ -150,7 +154,7 @@ class CommentServiceTest {
                 .getComments(
                         Accessor.member(loginMember.getId()),
                         post.getId(),
-                        PageRequest.of(0, COMMENT_PAGING_SIZE)
+                        PageRequest.of(0, COMMENT_PAGING_SIZE, Sort.by(Sort.Direction.ASC, "createdDate"))
                 );
         // then
         assertAll(

--- a/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/apps/pochak/comment/service/CommentServiceTest.java
@@ -16,6 +16,8 @@ import com.apps.pochak.tag.domain.repository.TagRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
@@ -32,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class CommentServiceTest {
 
+    private static final Logger log = LoggerFactory.getLogger(CommentServiceTest.class);
     @Autowired
     CommentService commentService;
 


### PR DESCRIPTION
## 📒 개요

댓글 정렬 조건 선택할 수 있게 pageable로 동적 쿼리 처리

## 📍 Issue 번호

- #189 

<!-- n에 작업 번호를 작성해주세요! -->

## 🛠️ 작업사항

- [x] getComments
- [x] getChildCommentByParentComment

## 🧰 추가 논의사항

- getComments 쿼리 재사용성이 떨어져서 리팩토링한다면 queryDSL로 해야 할듯요 .. 시간이 남는다면 차차하겠습니다