### PR TITLE
[Chore/#76-jacoco-sonar] SonarQuber 커버리지 제외 대상 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,6 @@ sonarqube {
         property "sonar.organization", "pochak-server"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.login", "${System.getenv('SONAR_TOKEN')}"
-        property "sonar.coverage.exclusions", Qdomains.join(", ")
+        property "sonar.coverage.exclusions", "**/entity/**, **/dto/**, **/config/**, **/global/image/**, **/domain/**, **/annotation/**"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,8 @@ for (qPattern in "**/QA".."**/QZ") {
 }
 
 Qdomains.add("com/apps/pochak/**/dto/**")
-
+Qdomains.add("com/apps/pochak/**/entity/**")
+Qdomains.add("com/apps/pochak/**/config/**")
 jacocoTestReport {
     dependsOn test
     dependsOn copyDocument
@@ -190,5 +191,6 @@ sonarqube {
         property "sonar.organization", "pochak-server"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.login", "${System.getenv('SONAR_TOKEN')}"
+        property "sonar.coverage.exclusions", Qdomains.join(", ")
     }
 }


### PR DESCRIPTION
## 📒 개요
- dto, config, entity를 커버리지 측정 대상에서 제거

## 📍 Issue 번호
#76 

## 🛠️ 작업사항
- [x] build.gradle 수정

## 🧰 추가 논의사항
-