### PR TITLE
[Fix/#189-comment-sort] 전체 댓글 조회시 sort 조건 null 허용

### DIFF
--- a/src/main/java/com/apps/pochak/comment/controller/CommentController.java
+++ b/src/main/java/com/apps/pochak/comment/controller/CommentController.java
@@ -30,7 +30,7 @@ public class CommentController {
     public ApiResponse<CommentElements> getComments(
             @Auth final Accessor accessor,
             @PathVariable("postId") final Long postId,
-            @PageableDefault(COMMENT_PAGING_SIZE) final Pageable pageable
+            @PageableDefault(size = COMMENT_PAGING_SIZE, sort = "createdDate", direction = Sort.Direction.ASC) final Pageable pageable
     ) {
         return ApiResponse.onSuccess(
                 commentService.getComments(
@@ -47,7 +47,7 @@ public class CommentController {
             @Auth final Accessor accessor,
             @PathVariable("postId") final Long postId,
             @PathVariable("parentCommentId") final Long parentCommentId,
-            @PageableDefault(size = COMMENT_PAGING_SIZE, sort = "createdDate", direction = Sort.Direction.ASC) final Pageable pageable
+            @PageableDefault(COMMENT_PAGING_SIZE) final Pageable pageable
     ) {
         return ApiResponse.onSuccess(
                 commentService.getChildCommentsByParentCommentId(

--- a/src/test/java/com/apps/pochak/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/apps/pochak/comment/controller/CommentControllerTest.java
@@ -103,7 +103,7 @@ class CommentControllerTest extends ControllerTest {
                                 queryParameters(
                                         parameterWithName("page").description("조회할 페이지 [default: 0]").optional(),
                                         parameterWithName("size").description("조회할 페이지 사이즈 [default: 10]").optional(),
-                                        parameterWithName("sort").description("조회할 페이지 정렬 조건 [format: createdDate,asc or desc]").optional()
+                                        parameterWithName("sort").description("조회할 페이지 정렬 조건 [default: createdDate,asc]").optional()
                                 ),
                                 responseFields(
                                         fieldWithPath("isSuccess").type(BOOLEAN).description("성공 여부"),


### PR DESCRIPTION
## 📒 개요

전체 댓글 조회(getComments)시 sort 조건 null 허용

## 📍 Issue 번호

- #189 
